### PR TITLE
Feature/app bundle only output

### DIFF
--- a/Decryption/TDDecryptionTask.h
+++ b/Decryption/TDDecryptionTask.h
@@ -4,11 +4,17 @@
 
 @class LSApplicationProxy;
 
+typedef NS_ENUM(NSInteger, TDDecryptionOutputMode) {
+    TDDecryptionOutputModeFullIPA = 0,
+    TDDecryptionOutputModeAppBundleOnly,
+    TDDecryptionOutputModeMainBinaryOnly,
+};
+
 typedef struct {
-    bool decryptBinaryOnly;
+    TDDecryptionOutputMode outputMode;
 } TDDecryptionTaskOptions;
 
-TDDecryptionTaskOptions TDDecryptionTaskOptionsMake(bool decryptBinaryOnly);
+TDDecryptionTaskOptions TDDecryptionTaskOptionsMake(TDDecryptionOutputMode outputMode);
 TDDecryptionTaskOptions TDDecryptionTaskDefaultOptions(void);
 
 @interface TDDecryptionTask : NSObject

--- a/Decryption/TDDecryptionTask.m
+++ b/Decryption/TDDecryptionTask.m
@@ -206,29 +206,83 @@ TDDecryptionTaskOptions TDDecryptionTaskDefaultOptions(void) {
             }
         }
 
-        progress([Localize localizedStringForKey:@"BUILDING_IPA"]);
-        NSString *outputIPAName =
-            [NSString stringWithFormat:@"%@_%@_decrypted.ipa",
-             bundleIdentifier, [self->_applicationProxy atl_shortVersionString]];
+        if (appBundleOnly) {
+            progress([Localize localizedStringForKey:@"SAVING_APP_BUNDLE"]);
 
-        if (![self _buildIPAWithName:outputIPAName]) {
-            NSError *ipaError = [TDError errorWithCode:TDErrorCodeIPAConstructionFailed];
+            NSError *moveError = nil;
+            [self->_fileManager moveItemAtPath:self->_destinationPath toPath:appBundleOutputPath error:&moveError];
+            if (moveError) {
+                NSLog(@"Failed to save App Bundle output at path %@, error: %@", appBundleOutputPath, moveError);
+
+                NSError *cleanupError = nil;
+                if ([self->_fileManager fileExistsAtPath:appBundleOutputPath]) {
+                    [self->_fileManager removeItemAtPath:appBundleOutputPath error:&cleanupError];
+                    if (cleanupError) NSLog(@"Failed to remove App Bundle output after save failure at path %@, error: %@", appBundleOutputPath, cleanupError);
+                }
+
+                cleanupError = nil;
+                if (self->_workingDirectoryPath && [self->_fileManager fileExistsAtPath:self->_workingDirectoryPath]) {
+                    [self->_fileManager removeItemAtPath:self->_workingDirectoryPath error:&cleanupError];
+                    if (cleanupError) NSLog(@"Failed to clean up working directory after App Bundle output failure: %@, error: %@", self->_workingDirectoryPath, cleanupError);
+                }
+
+                NSError *outputError = [TDError errorWithCode:TDErrorCodeAppBundleOutputFailed];
+                cleanupLaunchedProcesses();
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    if (completionHandler) completionHandler(NO, nil, outputError);
+                });
+                return;
+            }
+
+            NSError *cleanupError = nil;
+            if (self->_workingDirectoryPath && [self->_fileManager fileExistsAtPath:self->_workingDirectoryPath]) {
+                [self->_fileManager removeItemAtPath:self->_workingDirectoryPath error:&cleanupError];
+                if (cleanupError) NSLog(@"Failed to clean up working directory after App Bundle output: %@, error: %@", self->_workingDirectoryPath, cleanupError);
+            }
+
             cleanupLaunchedProcesses();
+            progress([Localize localizedStringForKey:@"DECRYPTION_COMPLETED"]);
+
             dispatch_async(dispatch_get_main_queue(), ^{
-                if (completionHandler) completionHandler(NO, nil, ipaError);
+                if (completionHandler) completionHandler(YES, [NSURL fileURLWithPath:appBundleOutputPath], nil);
             });
             return;
         }
 
+        if (fullIPA) {
+            progress([Localize localizedStringForKey:@"BUILDING_IPA"]);
+            NSString *outputIPAName =
+                [NSString stringWithFormat:@"%@_%@_decrypted.ipa",
+                 bundleIdentifier, [self->_applicationProxy atl_shortVersionString]];
+
+            if (![self _buildIPAWithName:outputIPAName]) {
+                NSError *ipaError = [TDError errorWithCode:TDErrorCodeIPAConstructionFailed];
+                cleanupLaunchedProcesses();
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    if (completionHandler) completionHandler(NO, nil, ipaError);
+                });
+                return;
+            }
+
+            cleanupLaunchedProcesses();
+            progress([Localize localizedStringForKey:@"DECRYPTION_COMPLETED"]);
+
+            NSString *ipaPath = [ROOT_OUTPUT_PATH stringByAppendingPathComponent:outputIPAName];
+            NSURL *url = [NSURL fileURLWithPath:ipaPath];
+
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (completionHandler) completionHandler(YES, url, nil);
+            });
+            return;
+        }
+
+        NSLog(@"Unknown output mode: %ld", (long)options.outputMode);
+        NSError *unknownError = [TDError errorWithCode:TDErrorCodeUnknown];
         cleanupLaunchedProcesses();
-        progress([Localize localizedStringForKey:@"DECRYPTION_COMPLETED"]);
-
-        NSString *ipaPath = [ROOT_OUTPUT_PATH stringByAppendingPathComponent:outputIPAName];
-        NSURL *url = [NSURL fileURLWithPath:ipaPath];
-
         dispatch_async(dispatch_get_main_queue(), ^{
-            if (completionHandler) completionHandler(YES, url, nil);
+            if (completionHandler) completionHandler(NO, nil, unknownError);
         });
+        return;
     });
 }
 

--- a/Decryption/TDDecryptionTask.m
+++ b/Decryption/TDDecryptionTask.m
@@ -12,14 +12,14 @@
 #import <MobileCoreServices/MobileCoreServices.h>
 #import "Extensions/LSBundleProxy+TrollDecrypt.h"
 
-TDDecryptionTaskOptions TDDecryptionTaskOptionsMake(bool decryptBinaryOnly) {
+TDDecryptionTaskOptions TDDecryptionTaskOptionsMake(TDDecryptionOutputMode outputMode) {
     TDDecryptionTaskOptions options = {0};
-    options.decryptBinaryOnly = decryptBinaryOnly;
+    options.outputMode = outputMode;
     return options;
 }
 
 TDDecryptionTaskOptions TDDecryptionTaskDefaultOptions(void) {
-    return TDDecryptionTaskOptionsMake(false);
+    return TDDecryptionTaskOptionsMake(TDDecryptionOutputModeFullIPA);
 }
 
 @implementation TDDecryptionTask {
@@ -54,6 +54,8 @@ TDDecryptionTaskOptions TDDecryptionTaskDefaultOptions(void) {
             });
         };
 
+        BOOL mainBinaryOnly = (options.outputMode == TDDecryptionOutputModeMainBinaryOnly);
+
         if (![self createOutputDirectoryIfNeeded]) {
             NSError *dirError = [TDError errorWithCode:TDErrorCodeUnknown];
             dispatch_async(dispatch_get_main_queue(), ^{
@@ -76,7 +78,7 @@ TDDecryptionTaskOptions TDDecryptionTaskDefaultOptions(void) {
 
         pid_t targetPID = response.pid;
 
-        if (!options.decryptBinaryOnly) {    
+        if (!mainBinaryOnly) {    
             progress([Localize localizedStringForKey:@"COPYING_BUNDLE"]);
             if (![self _copyApplicationBundle]) {
                 NSError *copyError = [TDError errorWithCode:TDErrorCodeApplicationBundleCopyFailed];
@@ -93,7 +95,7 @@ TDDecryptionTaskOptions TDDecryptionTaskDefaultOptions(void) {
 
         BOOL status = false;
         NSString *fullOutputPath = nil;
-        if (options.decryptBinaryOnly) {
+        if (mainBinaryOnly) {
             NSLog(@"Decrypting main binary only to output directory: %@", ROOT_OUTPUT_PATH);
             NSLog(@"image path: %@", imagePath);
             NSString *fileName = [NSString stringWithFormat:@"%@_%@_decrypted",
@@ -114,7 +116,7 @@ TDDecryptionTaskOptions TDDecryptionTaskDefaultOptions(void) {
             return;
         }
 
-        if (options.decryptBinaryOnly) {
+        if (mainBinaryOnly) {
             kill(targetPID, SIGKILL);
             progress([Localize localizedStringForKey:@"DECRYPTION_COMPLETED"]);
 

--- a/Decryption/TDDecryptionTask.m
+++ b/Decryption/TDDecryptionTask.m
@@ -95,6 +95,23 @@ TDDecryptionTaskOptions TDDecryptionTaskDefaultOptions(void) {
             [launchedPIDs removeAllObjects];
         };
 
+        void (^cleanupAppBundleOutput)(void) = ^{
+            if (!appBundleOnly) return;
+
+            NSError *cleanupError = nil;
+            if ([self->_fileManager fileExistsAtPath:appBundleOutputPath]) {
+                [self->_fileManager removeItemAtPath:appBundleOutputPath error:&cleanupError];
+                if (cleanupError) NSLog(@"Failed to remove partial App Bundle output at path %@, error: %@", appBundleOutputPath, cleanupError);
+            }
+
+            cleanupError = nil;
+            NSString *workingDirectoryPath = self->_workingDirectoryPath ?: [ROOT_OUTPUT_PATH stringByAppendingPathComponent:@".work"];
+            if ([self->_fileManager fileExistsAtPath:workingDirectoryPath]) {
+                [self->_fileManager removeItemAtPath:workingDirectoryPath error:&cleanupError];
+                if (cleanupError) NSLog(@"Failed to remove App Bundle working directory at path %@, error: %@", workingDirectoryPath, cleanupError);
+            }
+        };
+
         progress([Localize localizedStringForKey:@"LAUNCHING_APPLICATION"]);
 
         LaunchdResponse_t response = [self->_applicationProxy td_launchProcess];
@@ -114,6 +131,7 @@ TDDecryptionTaskOptions TDDecryptionTaskDefaultOptions(void) {
             progress([Localize localizedStringForKey:@"COPYING_BUNDLE"]);
             if (![self _copyApplicationBundle]) {
                 NSError *copyError = [TDError errorWithCode:TDErrorCodeApplicationBundleCopyFailed];
+                cleanupAppBundleOutput();
                 cleanupLaunchedProcesses();
                 dispatch_async(dispatch_get_main_queue(), ^{
                     if (completionHandler) completionHandler(NO, nil, copyError);
@@ -143,6 +161,7 @@ TDDecryptionTaskOptions TDDecryptionTaskDefaultOptions(void) {
 
         if (!status) {
             NSError *decryptError = [TDError errorWithCode:TDErrorCodeBinaryDecryptionFailed];
+            cleanupAppBundleOutput();
             cleanupLaunchedProcesses();
             dispatch_async(dispatch_get_main_queue(), ^{
                 if (completionHandler) completionHandler(NO, nil, decryptError);
@@ -214,19 +233,8 @@ TDDecryptionTaskOptions TDDecryptionTaskDefaultOptions(void) {
             if (moveError) {
                 NSLog(@"Failed to save App Bundle output at path %@, error: %@", appBundleOutputPath, moveError);
 
-                NSError *cleanupError = nil;
-                if ([self->_fileManager fileExistsAtPath:appBundleOutputPath]) {
-                    [self->_fileManager removeItemAtPath:appBundleOutputPath error:&cleanupError];
-                    if (cleanupError) NSLog(@"Failed to remove App Bundle output after save failure at path %@, error: %@", appBundleOutputPath, cleanupError);
-                }
-
-                cleanupError = nil;
-                if (self->_workingDirectoryPath && [self->_fileManager fileExistsAtPath:self->_workingDirectoryPath]) {
-                    [self->_fileManager removeItemAtPath:self->_workingDirectoryPath error:&cleanupError];
-                    if (cleanupError) NSLog(@"Failed to clean up working directory after App Bundle output failure: %@, error: %@", self->_workingDirectoryPath, cleanupError);
-                }
-
                 NSError *outputError = [TDError errorWithCode:TDErrorCodeAppBundleOutputFailed];
+                cleanupAppBundleOutput();
                 cleanupLaunchedProcesses();
                 dispatch_async(dispatch_get_main_queue(), ^{
                     if (completionHandler) completionHandler(NO, nil, outputError);
@@ -278,6 +286,7 @@ TDDecryptionTaskOptions TDDecryptionTaskDefaultOptions(void) {
 
         NSLog(@"Unknown output mode: %ld", (long)options.outputMode);
         NSError *unknownError = [TDError errorWithCode:TDErrorCodeUnknown];
+        cleanupAppBundleOutput();
         cleanupLaunchedProcesses();
         dispatch_async(dispatch_get_main_queue(), ^{
             if (completionHandler) completionHandler(NO, nil, unknownError);

--- a/Decryption/TDDecryptionTask.m
+++ b/Decryption/TDDecryptionTask.m
@@ -84,6 +84,17 @@ TDDecryptionTaskOptions TDDecryptionTaskDefaultOptions(void) {
             }
         }
 
+        NSMutableArray<NSNumber *> *launchedPIDs = [NSMutableArray array];
+        void (^cleanupLaunchedProcesses)(void) = ^{
+            for (NSNumber *pidNumber in launchedPIDs) {
+                pid_t pid = (pid_t)pidNumber.intValue;
+                if (pid > 0) {
+                    kill(pid, SIGKILL);
+                }
+            }
+            [launchedPIDs removeAllObjects];
+        };
+
         progress([Localize localizedStringForKey:@"LAUNCHING_APPLICATION"]);
 
         LaunchdResponse_t response = [self->_applicationProxy td_launchProcess];
@@ -97,11 +108,13 @@ TDDecryptionTaskOptions TDDecryptionTaskDefaultOptions(void) {
         }
 
         pid_t targetPID = response.pid;
+        [launchedPIDs addObject:@(targetPID)];
 
         if (!mainBinaryOnly) {    
             progress([Localize localizedStringForKey:@"COPYING_BUNDLE"]);
             if (![self _copyApplicationBundle]) {
                 NSError *copyError = [TDError errorWithCode:TDErrorCodeApplicationBundleCopyFailed];
+                cleanupLaunchedProcesses();
                 dispatch_async(dispatch_get_main_queue(), ^{
                     if (completionHandler) completionHandler(NO, nil, copyError);
                 });
@@ -130,6 +143,7 @@ TDDecryptionTaskOptions TDDecryptionTaskDefaultOptions(void) {
 
         if (!status) {
             NSError *decryptError = [TDError errorWithCode:TDErrorCodeBinaryDecryptionFailed];
+            cleanupLaunchedProcesses();
             dispatch_async(dispatch_get_main_queue(), ^{
                 if (completionHandler) completionHandler(NO, nil, decryptError);
             });
@@ -137,7 +151,7 @@ TDDecryptionTaskOptions TDDecryptionTaskDefaultOptions(void) {
         }
 
         if (mainBinaryOnly) {
-            kill(targetPID, SIGKILL);
+            cleanupLaunchedProcesses();
             progress([Localize localizedStringForKey:@"DECRYPTION_COMPLETED"]);
 
             dispatch_async(dispatch_get_main_queue(), ^{
@@ -180,6 +194,7 @@ TDDecryptionTaskOptions TDDecryptionTaskDefaultOptions(void) {
                 NSLog(@"Failed to launch extension %@", extension.bundleIdentifier);
                 continue;
             }
+            [launchedPIDs addObject:@(extensionResponse.pid)];
 
             currentExtensionIndex++;
             progress([NSString stringWithFormat:@"Decrypting extension %ld/%ld...",
@@ -189,8 +204,6 @@ TDDecryptionTaskOptions TDDecryptionTaskDefaultOptions(void) {
             if (![self decryptImageAtPath:extensionImagePath forPID:extensionResponse.pid]) {
                 NSLog(@"Failed to decrypt main executable for extension %@", extension.bundleIdentifier);
             }
-
-            kill(extensionResponse.pid, SIGKILL);
         }
 
         progress([Localize localizedStringForKey:@"BUILDING_IPA"]);
@@ -200,13 +213,14 @@ TDDecryptionTaskOptions TDDecryptionTaskDefaultOptions(void) {
 
         if (![self _buildIPAWithName:outputIPAName]) {
             NSError *ipaError = [TDError errorWithCode:TDErrorCodeIPAConstructionFailed];
+            cleanupLaunchedProcesses();
             dispatch_async(dispatch_get_main_queue(), ^{
                 if (completionHandler) completionHandler(NO, nil, ipaError);
             });
             return;
         }
 
-        kill(targetPID, SIGKILL);
+        cleanupLaunchedProcesses();
         progress([Localize localizedStringForKey:@"DECRYPTION_COMPLETED"]);
 
         NSString *ipaPath = [ROOT_OUTPUT_PATH stringByAppendingPathComponent:outputIPAName];

--- a/Decryption/TDDecryptionTask.m
+++ b/Decryption/TDDecryptionTask.m
@@ -55,6 +55,8 @@ TDDecryptionTaskOptions TDDecryptionTaskDefaultOptions(void) {
         };
 
         BOOL mainBinaryOnly = (options.outputMode == TDDecryptionOutputModeMainBinaryOnly);
+        BOOL appBundleOnly = (options.outputMode == TDDecryptionOutputModeAppBundleOnly);
+        BOOL fullIPA = (options.outputMode == TDDecryptionOutputModeFullIPA);
 
         if (![self createOutputDirectoryIfNeeded]) {
             NSError *dirError = [TDError errorWithCode:TDErrorCodeUnknown];
@@ -62,6 +64,24 @@ TDDecryptionTaskOptions TDDecryptionTaskDefaultOptions(void) {
                 if (completionHandler) completionHandler(NO, nil, dirError);
             });
             return;
+        }
+
+        NSString *appBundleOutputName =
+            [NSString stringWithFormat:@"%@_%@_decrypted.app",
+             bundleIdentifier, [self->_applicationProxy atl_shortVersionString]];
+        NSString *appBundleOutputPath = [ROOT_OUTPUT_PATH stringByAppendingPathComponent:appBundleOutputName];
+
+        if (appBundleOnly && [self->_fileManager fileExistsAtPath:appBundleOutputPath]) {
+            NSError *removeError = nil;
+            [self->_fileManager removeItemAtPath:appBundleOutputPath error:&removeError];
+            if (removeError) {
+                NSLog(@"Failed to remove existing App Bundle output at path %@, error: %@", appBundleOutputPath, removeError);
+                NSError *outputError = [TDError errorWithCode:TDErrorCodeAppBundleOutputFailed];
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    if (completionHandler) completionHandler(NO, nil, outputError);
+                });
+                return;
+            }
         }
 
         progress([Localize localizedStringForKey:@"LAUNCHING_APPLICATION"]);

--- a/Decryption/TDError.h
+++ b/Decryption/TDError.h
@@ -5,7 +5,8 @@ typedef NS_ENUM(NSInteger, TDErrorCode) {
     TDErrorCodeApplicationBundleCopyFailed,
     TDErrorCodeBinaryDecryptionFailed,
     TDErrorCodeLaunchFailed,
-    TDErrorCodeIPAConstructionFailed
+    TDErrorCodeIPAConstructionFailed,
+    TDErrorCodeAppBundleOutputFailed
 };
 
 @interface TDError : NSError

--- a/Decryption/TDError.m
+++ b/Decryption/TDError.m
@@ -19,6 +19,8 @@
             return @"Application launch failed";
         case TDErrorCodeIPAConstructionFailed:
             return @"IPA construction failed";
+        case TDErrorCodeAppBundleOutputFailed:
+            return @"App bundle output failed";
         case TDErrorCodeUnknown:
         default:
             return @"Unknown error";

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -172,6 +172,10 @@
 	<string>1.2.3</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>filza</string>
+	</array>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>

--- a/Resources/ar.lproj/Localizable.strings
+++ b/Resources/ar.lproj/Localizable.strings
@@ -16,6 +16,7 @@ DECRYPTED_BINARIES = "الملفات الثنائية المفكوكة التش�
 
 DECRYPTION_PROMPT = "هل تريد فك تشفير %@؟";
 MAIN_BINARY_ONLY = "الملف الثنائي الرئيسي فقط";
+APP_BUNDLE_ONLY = "App Bundle Only";
 FULL_IPA = "ملف IPA كامل";
 
 LAUNCHING_APPLICATION = "جارٍ تشغيل التطبيق...";

--- a/Resources/ar.lproj/Localizable.strings
+++ b/Resources/ar.lproj/Localizable.strings
@@ -22,6 +22,7 @@ FULL_IPA = "ملف IPA كامل";
 LAUNCHING_APPLICATION = "جارٍ تشغيل التطبيق...";
 COPYING_BUNDLE = "جارٍ نسخ حزمة التطبيق...";
 DECRYPTING_BINARY = "جارٍ فك تشفير الملف الثنائي...";
+SAVING_APP_BUNDLE = "Saving app bundle...";
 DECRYPTION_COMPLETED = "تم فك التشفير!";
 BUILDING_IPA = "جارٍ إنشاء ملف IPA... (قد يستغرق ذلك دقيقة)";
 

--- a/Resources/ar.lproj/Localizable.strings
+++ b/Resources/ar.lproj/Localizable.strings
@@ -12,6 +12,7 @@ DECRYPT_APPS = "فك تشفير التطبيقات";
 DECRYPTED_FILES = "الملفات المفكوكة التشفير";
 
 DECRYPTED_IPAS = "ملفات IPA المفكوكة التشفير (%lu)";
+DECRYPTED_APP_BUNDLES = "Decrypted App Bundles (%lu)";
 DECRYPTED_BINARIES = "الملفات الثنائية المفكوكة التشفير (%lu)";
 
 DECRYPTION_PROMPT = "هل تريد فك تشفير %@؟";
@@ -32,4 +33,5 @@ MANUAL_ENTRY_TITLE = "إدخال معرف الحزمة يدويًا";
 MANUAL_ENTRY_SUBTITLE = "أدخل معرف حزمة التطبيق الذي تريد فك تشفيره.";
 
 SHOW_IN_FILZA = "عرض في Filza";
+COPY_PATH = "Copy Path";
 SHOW_IN_FILES = "عرض في الملفات";

--- a/Resources/ca.lproj/Localizable.strings
+++ b/Resources/ca.lproj/Localizable.strings
@@ -16,6 +16,7 @@ DECRYPTED_BINARIES = "Binaris desxifrats (%lu)";
 
 DECRYPTION_PROMPT = "Vols desxifrar %@?";
 MAIN_BINARY_ONLY = "Només binari principal";
+APP_BUNDLE_ONLY = "App Bundle Only";
 FULL_IPA = "IPA complet";
 
 LAUNCHING_APPLICATION = "S'està iniciant l'aplicació...";

--- a/Resources/ca.lproj/Localizable.strings
+++ b/Resources/ca.lproj/Localizable.strings
@@ -22,6 +22,7 @@ FULL_IPA = "IPA complet";
 LAUNCHING_APPLICATION = "S'està iniciant l'aplicació...";
 COPYING_BUNDLE = "S'està copiant el paquet de l'aplicació...";
 DECRYPTING_BINARY = "S'està desxifrant el binari...";
+SAVING_APP_BUNDLE = "Saving app bundle...";
 DECRYPTION_COMPLETED = "Desxifrat complet!";
 BUILDING_IPA = "S'està creant l'IPA... (Això pot trigar un minut)";
 

--- a/Resources/ca.lproj/Localizable.strings
+++ b/Resources/ca.lproj/Localizable.strings
@@ -12,6 +12,7 @@ DECRYPT_APPS = "Desxifra aplicacions";
 DECRYPTED_FILES = "Fitxers desxifrats";
 
 DECRYPTED_IPAS = "IPAs desxifrats (%lu)";
+DECRYPTED_APP_BUNDLES = "Decrypted App Bundles (%lu)";
 DECRYPTED_BINARIES = "Binaris desxifrats (%lu)";
 
 DECRYPTION_PROMPT = "Vols desxifrar %@?";
@@ -32,4 +33,5 @@ MANUAL_ENTRY_TITLE = "Identificador de paquet manual";
 MANUAL_ENTRY_SUBTITLE = "Introdueix l'identificador de paquet de l'aplicació que vols desxifrar.";
 
 SHOW_IN_FILZA = "Mostra a Filza";
+COPY_PATH = "Copy Path";
 SHOW_IN_FILES = "Mostra a Fitxers";

--- a/Resources/cs.lproj/Localizable.strings
+++ b/Resources/cs.lproj/Localizable.strings
@@ -12,6 +12,7 @@ DECRYPT_APPS = "Dešifrovat aplikace";
 DECRYPTED_FILES = "Dešifrované soubory";
 
 DECRYPTED_IPAS = "Dešifrované IPA (%lu)";
+DECRYPTED_APP_BUNDLES = "Decrypted App Bundles (%lu)";
 DECRYPTED_BINARIES = "Dešifrované binárky (%lu)";
 
 DECRYPTION_PROMPT = "Chcete dešifrovat %@?";
@@ -32,4 +33,5 @@ MANUAL_ENTRY_TITLE = "Manuální identifikátor balíčku";
 MANUAL_ENTRY_SUBTITLE = "Zadejte identifikátor balíčku aplikace, kterou chcete dešifrovat.";
 
 SHOW_IN_FILZA = "Zobrazit ve Filza";
+COPY_PATH = "Copy Path";
 SHOW_IN_FILES = "Zobrazit v Souborech";

--- a/Resources/cs.lproj/Localizable.strings
+++ b/Resources/cs.lproj/Localizable.strings
@@ -22,6 +22,7 @@ FULL_IPA = "Celé IPA";
 LAUNCHING_APPLICATION = "Spouštění aplikace...";
 COPYING_BUNDLE = "Kopírování aplikačního balíčku...";
 DECRYPTING_BINARY = "Dešifrování binárky...";
+SAVING_APP_BUNDLE = "Saving app bundle...";
 DECRYPTION_COMPLETED = "Dešifrování dokončeno!";
 BUILDING_IPA = "Vytváření IPA... (Může to chvíli trvat)";
 

--- a/Resources/cs.lproj/Localizable.strings
+++ b/Resources/cs.lproj/Localizable.strings
@@ -16,6 +16,7 @@ DECRYPTED_BINARIES = "Dešifrované binárky (%lu)";
 
 DECRYPTION_PROMPT = "Chcete dešifrovat %@?";
 MAIN_BINARY_ONLY = "Pouze hlavní binárka";
+APP_BUNDLE_ONLY = "App Bundle Only";
 FULL_IPA = "Celé IPA";
 
 LAUNCHING_APPLICATION = "Spouštění aplikace...";

--- a/Resources/da.lproj/Localizable.strings
+++ b/Resources/da.lproj/Localizable.strings
@@ -16,6 +16,7 @@ DECRYPTED_BINARIES = "Dekrypterede binære filer (%lu)";
 
 DECRYPTION_PROMPT = "Vil du dekryptere %@?";
 MAIN_BINARY_ONLY = "Kun hovedbinær";
+APP_BUNDLE_ONLY = "App Bundle Only";
 FULL_IPA = "Fuld IPA";
 
 LAUNCHING_APPLICATION = "Starter applikation...";

--- a/Resources/da.lproj/Localizable.strings
+++ b/Resources/da.lproj/Localizable.strings
@@ -12,6 +12,7 @@ DECRYPT_APPS = "Dekrypter apps";
 DECRYPTED_FILES = "Dekrypterede filer";
 
 DECRYPTED_IPAS = "Dekrypterede IPA'er (%lu)";
+DECRYPTED_APP_BUNDLES = "Decrypted App Bundles (%lu)";
 DECRYPTED_BINARIES = "Dekrypterede binære filer (%lu)";
 
 DECRYPTION_PROMPT = "Vil du dekryptere %@?";
@@ -32,4 +33,5 @@ MANUAL_ENTRY_TITLE = "Manuel bundle-identifikator";
 MANUAL_ENTRY_SUBTITLE = "Indtast bundle-identifikatoren for den applikation, du vil dekryptere.";
 
 SHOW_IN_FILZA = "Vis i Filza";
+COPY_PATH = "Copy Path";
 SHOW_IN_FILES = "Vis i Filer";

--- a/Resources/da.lproj/Localizable.strings
+++ b/Resources/da.lproj/Localizable.strings
@@ -22,6 +22,7 @@ FULL_IPA = "Fuld IPA";
 LAUNCHING_APPLICATION = "Starter applikation...";
 COPYING_BUNDLE = "Kopierer applikationspakke...";
 DECRYPTING_BINARY = "Dekrypterer binær...";
+SAVING_APP_BUNDLE = "Saving app bundle...";
 DECRYPTION_COMPLETED = "Dekryptering fuldført!";
 BUILDING_IPA = "Bygger IPA... (Dette kan tage et minut)";
 

--- a/Resources/de.lproj/Localizable.strings
+++ b/Resources/de.lproj/Localizable.strings
@@ -12,6 +12,7 @@ DECRYPT_APPS = "Apps entschlüsseln";
 DECRYPTED_FILES = "Entschlüsselte Dateien";
 
 DECRYPTED_IPAS = "Entschlüsselte IPAs (%lu)";
+DECRYPTED_APP_BUNDLES = "Decrypted App Bundles (%lu)";
 DECRYPTED_BINARIES = "Entschlüsselte Binärdateien (%lu)";
 
 DECRYPTION_PROMPT = "Möchten Sie %@ entschlüsseln?";
@@ -32,4 +33,5 @@ MANUAL_ENTRY_TITLE = "Manuelle Bundle-ID";
 MANUAL_ENTRY_SUBTITLE = "Geben Sie die Bundle-ID der App ein, die Sie entschlüsseln möchten.";
 
 SHOW_IN_FILZA = "In Filza anzeigen";
+COPY_PATH = "Copy Path";
 SHOW_IN_FILES = "In Dateien anzeigen";

--- a/Resources/de.lproj/Localizable.strings
+++ b/Resources/de.lproj/Localizable.strings
@@ -16,6 +16,7 @@ DECRYPTED_BINARIES = "Entschlüsselte Binärdateien (%lu)";
 
 DECRYPTION_PROMPT = "Möchten Sie %@ entschlüsseln?";
 MAIN_BINARY_ONLY = "Nur Haupt-Binärdatei";
+APP_BUNDLE_ONLY = "App Bundle Only";
 FULL_IPA = "Komplettes IPA";
 
 LAUNCHING_APPLICATION = "Anwendung wird gestartet...";

--- a/Resources/de.lproj/Localizable.strings
+++ b/Resources/de.lproj/Localizable.strings
@@ -22,6 +22,7 @@ FULL_IPA = "Komplettes IPA";
 LAUNCHING_APPLICATION = "Anwendung wird gestartet...";
 COPYING_BUNDLE = "Anwendungspaket wird kopiert...";
 DECRYPTING_BINARY = "Binärdatei wird entschlüsselt...";
+SAVING_APP_BUNDLE = "Saving app bundle...";
 DECRYPTION_COMPLETED = "Entschlüsselung abgeschlossen!";
 BUILDING_IPA = "IPA wird erstellt... (Dies kann eine Minute dauern)";
 

--- a/Resources/el.lproj/Localizable.strings
+++ b/Resources/el.lproj/Localizable.strings
@@ -22,6 +22,7 @@ FULL_IPA = "Ολόκληρο IPA";
 LAUNCHING_APPLICATION = "Εκκίνηση Εφαρμογής...";
 COPYING_BUNDLE = "Αντιγραφή Πακέτου Εφαρμογής...";
 DECRYPTING_BINARY = "Αποκρυπτογράφηση Δυαδικού...";
+SAVING_APP_BUNDLE = "Saving app bundle...";
 DECRYPTION_COMPLETED = "Η αποκρυπτογράφηση ολοκληρώθηκε!";
 BUILDING_IPA = "Δημιουργία IPA... (Αυτό μπορεί να διαρκέσει ένα λεπτό)";
 

--- a/Resources/el.lproj/Localizable.strings
+++ b/Resources/el.lproj/Localizable.strings
@@ -16,6 +16,7 @@ DECRYPTED_BINARIES = "Αποκρυπτογραφημένα Δυαδικά (%lu)"
 
 DECRYPTION_PROMPT = "Θέλετε να αποκρυπτογραφήσετε το %@;";
 MAIN_BINARY_ONLY = "Μόνο Κύριο Δυαδικό";
+APP_BUNDLE_ONLY = "App Bundle Only";
 FULL_IPA = "Ολόκληρο IPA";
 
 LAUNCHING_APPLICATION = "Εκκίνηση Εφαρμογής...";

--- a/Resources/el.lproj/Localizable.strings
+++ b/Resources/el.lproj/Localizable.strings
@@ -12,6 +12,7 @@ DECRYPT_APPS = "Αποκρυπτογράφηση Εφαρμογών";
 DECRYPTED_FILES = "Αποκρυπτογραφημένα Αρχεία";
 
 DECRYPTED_IPAS = "Αποκρυπτογραφημένα IPA (%lu)";
+DECRYPTED_APP_BUNDLES = "Decrypted App Bundles (%lu)";
 DECRYPTED_BINARIES = "Αποκρυπτογραφημένα Δυαδικά (%lu)";
 
 DECRYPTION_PROMPT = "Θέλετε να αποκρυπτογραφήσετε το %@;";
@@ -32,4 +33,5 @@ MANUAL_ENTRY_TITLE = "Χειροκίνητο Bundle Identifier";
 MANUAL_ENTRY_SUBTITLE = "Εισάγετε το bundle identifier της εφαρμογής που θέλετε να αποκρυπτογραφήσετε.";
 
 SHOW_IN_FILZA = "Εμφάνιση στο Filza";
+COPY_PATH = "Copy Path";
 SHOW_IN_FILES = "Εμφάνιση στα Αρχεία";

--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -22,6 +22,7 @@ FULL_IPA = "Full IPA";
 LAUNCHING_APPLICATION = "Launching Application...";
 COPYING_BUNDLE = "Copying Application Bundle...";
 DECRYPTING_BINARY = "Decrypting Binary...";
+SAVING_APP_BUNDLE = "Saving app bundle...";
 DECRYPTION_COMPLETED = "Decryption Complete!";
 BUILDING_IPA = "Building IPA... (This might take a minute)";
 

--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -12,6 +12,7 @@ DECRYPT_APPS = "Decrypt Apps";
 DECRYPTED_FILES = "Decrypted Files";
 
 DECRYPTED_IPAS = "Decrypted IPAs (%lu)";
+DECRYPTED_APP_BUNDLES = "Decrypted App Bundles (%lu)";
 DECRYPTED_BINARIES = "Decrypted Binaries (%lu)";
 
 DECRYPTION_PROMPT = "Do you want to decrypt %@?";
@@ -32,4 +33,5 @@ MANUAL_ENTRY_TITLE = "Manual Bundle Identifier";
 MANUAL_ENTRY_SUBTITLE = "Enter the bundle identifier of the application you want to decrypt.";
 
 SHOW_IN_FILZA = "Show in Filza";
+COPY_PATH = "Copy Path";
 SHOW_IN_FILES = "Show in Files";

--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -16,6 +16,7 @@ DECRYPTED_BINARIES = "Decrypted Binaries (%lu)";
 
 DECRYPTION_PROMPT = "Do you want to decrypt %@?";
 MAIN_BINARY_ONLY = "Main Binary Only";
+APP_BUNDLE_ONLY = "App Bundle Only";
 FULL_IPA = "Full IPA";
 
 LAUNCHING_APPLICATION = "Launching Application...";

--- a/Resources/es.lproj/Localizable.strings
+++ b/Resources/es.lproj/Localizable.strings
@@ -12,6 +12,7 @@ DECRYPT_APPS = "Descifrar Apps";
 DECRYPTED_FILES = "Archivos Descifrados";
 
 DECRYPTED_IPAS = "IPAs Descifrados (%lu)";
+DECRYPTED_APP_BUNDLES = "Decrypted App Bundles (%lu)";
 DECRYPTED_BINARIES = "Binarios Descifrados (%lu)";
 
 DECRYPTION_PROMPT = "¿Desea descifrar %@?";
@@ -32,4 +33,5 @@ MANUAL_ENTRY_TITLE = "Identificador de Paquete Manual";
 MANUAL_ENTRY_SUBTITLE = "Ingrese el identificador de paquete de la aplicación que desea descifrar.";
 
 SHOW_IN_FILZA = "Mostrar en Filza";
+COPY_PATH = "Copy Path";
 SHOW_IN_FILES = "Mostrar en Archivos";

--- a/Resources/es.lproj/Localizable.strings
+++ b/Resources/es.lproj/Localizable.strings
@@ -22,6 +22,7 @@ FULL_IPA = "IPA Completo";
 LAUNCHING_APPLICATION = "Iniciando Aplicación...";
 COPYING_BUNDLE = "Copiando Paquete de la Aplicación...";
 DECRYPTING_BINARY = "Descifrando Binario...";
+SAVING_APP_BUNDLE = "Saving app bundle...";
 DECRYPTION_COMPLETED = "¡Descifrado Completo!";
 BUILDING_IPA = "Construyendo IPA... (Esto puede tardar un minuto)";
 

--- a/Resources/es.lproj/Localizable.strings
+++ b/Resources/es.lproj/Localizable.strings
@@ -16,6 +16,7 @@ DECRYPTED_BINARIES = "Binarios Descifrados (%lu)";
 
 DECRYPTION_PROMPT = "¿Desea descifrar %@?";
 MAIN_BINARY_ONLY = "Solo Binario Principal";
+APP_BUNDLE_ONLY = "App Bundle Only";
 FULL_IPA = "IPA Completo";
 
 LAUNCHING_APPLICATION = "Iniciando Aplicación...";

--- a/Resources/fr.lproj/Localizable.strings
+++ b/Resources/fr.lproj/Localizable.strings
@@ -16,6 +16,7 @@ DECRYPTED_BINARIES = "Binaires déchiffrés (%lu)";
 
 DECRYPTION_PROMPT = "Voulez-vous déchiffrer %@ ?";
 MAIN_BINARY_ONLY = "Binaire principal uniquement";
+APP_BUNDLE_ONLY = "App Bundle Only";
 FULL_IPA = "IPA complet";
 
 LAUNCHING_APPLICATION = "Lancement de l’application...";

--- a/Resources/fr.lproj/Localizable.strings
+++ b/Resources/fr.lproj/Localizable.strings
@@ -12,6 +12,7 @@ DECRYPT_APPS = "Déchiffrer les applications";
 DECRYPTED_FILES = "Fichiers déchiffrés";
 
 DECRYPTED_IPAS = "IPAs déchiffrés (%lu)";
+DECRYPTED_APP_BUNDLES = "Decrypted App Bundles (%lu)";
 DECRYPTED_BINARIES = "Binaires déchiffrés (%lu)";
 
 DECRYPTION_PROMPT = "Voulez-vous déchiffrer %@ ?";
@@ -32,4 +33,5 @@ MANUAL_ENTRY_TITLE = "Identifiant du bundle manuel";
 MANUAL_ENTRY_SUBTITLE = "Entrez l’identifiant du bundle de l’application que vous souhaitez déchiffrer.";
 
 SHOW_IN_FILZA = "Afficher dans Filza";
+COPY_PATH = "Copy Path";
 SHOW_IN_FILES = "Afficher dans Fichiers";

--- a/Resources/fr.lproj/Localizable.strings
+++ b/Resources/fr.lproj/Localizable.strings
@@ -22,6 +22,7 @@ FULL_IPA = "IPA complet";
 LAUNCHING_APPLICATION = "Lancement de l’application...";
 COPYING_BUNDLE = "Copie du bundle de l’application...";
 DECRYPTING_BINARY = "Déchiffrement du binaire...";
+SAVING_APP_BUNDLE = "Saving app bundle...";
 DECRYPTION_COMPLETED = "Déchiffrement terminé !";
 BUILDING_IPA = "Création de l’IPA... (Cela peut prendre une minute)";
 

--- a/Resources/he.lproj/Localizable.strings
+++ b/Resources/he.lproj/Localizable.strings
@@ -12,6 +12,7 @@ DECRYPT_APPS = "פענוח אפליקציות";
 DECRYPTED_FILES = "קבצים מפוענחים";
 
 DECRYPTED_IPAS = "קבצי IPA מפוענחים (%lu)";
+DECRYPTED_APP_BUNDLES = "Decrypted App Bundles (%lu)";
 DECRYPTED_BINARIES = "בינאריים מפוענחים (%lu)";
 
 DECRYPTION_PROMPT = "האם ברצונך לפענח את %@?";
@@ -32,4 +33,5 @@ MANUAL_ENTRY_TITLE = "מזהה חבילה ידני";
 MANUAL_ENTRY_SUBTITLE = "הזן את מזהה החבילה של האפליקציה שברצונך לפענח.";
 
 SHOW_IN_FILZA = "הצג ב-Filza";
+COPY_PATH = "Copy Path";
 SHOW_IN_FILES = "הצג בקבצים";

--- a/Resources/he.lproj/Localizable.strings
+++ b/Resources/he.lproj/Localizable.strings
@@ -22,6 +22,7 @@ FULL_IPA = "IPA מלא";
 LAUNCHING_APPLICATION = "מפעיל את האפליקציה...";
 COPYING_BUNDLE = "מעתיק את חבילת האפליקציה...";
 DECRYPTING_BINARY = "מפענח את הקובץ הבינארי...";
+SAVING_APP_BUNDLE = "Saving app bundle...";
 DECRYPTION_COMPLETED = "הפענוח הושלם!";
 BUILDING_IPA = "בונה קובץ IPA... (זה עשוי לקחת דקה)";
 

--- a/Resources/he.lproj/Localizable.strings
+++ b/Resources/he.lproj/Localizable.strings
@@ -16,6 +16,7 @@ DECRYPTED_BINARIES = "בינאריים מפוענחים (%lu)";
 
 DECRYPTION_PROMPT = "האם ברצונך לפענח את %@?";
 MAIN_BINARY_ONLY = "בינארי ראשי בלבד";
+APP_BUNDLE_ONLY = "App Bundle Only";
 FULL_IPA = "IPA מלא";
 
 LAUNCHING_APPLICATION = "מפעיל את האפליקציה...";

--- a/Resources/hi.lproj/Localizable.strings
+++ b/Resources/hi.lproj/Localizable.strings
@@ -12,6 +12,7 @@ DECRYPT_APPS = "ऐप्स डिक्रिप्ट करें";
 DECRYPTED_FILES = "डिक्रिप्ट की गई फाइलें";
 
 DECRYPTED_IPAS = "डिक्रिप्ट की गई IPA (%lu)";
+DECRYPTED_APP_BUNDLES = "Decrypted App Bundles (%lu)";
 DECRYPTED_BINARIES = "डिक्रिप्ट किए गए बाइनरी (%lu)";
 
 DECRYPTION_PROMPT = "क्या आप %@ को डिक्रिप्ट करना चाहते हैं?";
@@ -32,4 +33,5 @@ MANUAL_ENTRY_TITLE = "मैन्युअल बंडल पहचानक�
 MANUAL_ENTRY_SUBTITLE = "उस एप्लिकेशन का बंडल पहचानकर्ता दर्ज करें जिसे आप डिक्रिप्ट करना चाहते हैं।";
 
 SHOW_IN_FILZA = "Filza में दिखाएं";
+COPY_PATH = "Copy Path";
 SHOW_IN_FILES = "Files में दिखाएं";

--- a/Resources/hi.lproj/Localizable.strings
+++ b/Resources/hi.lproj/Localizable.strings
@@ -22,6 +22,7 @@ FULL_IPA = "पूर्ण IPA";
 LAUNCHING_APPLICATION = "एप्लिकेशन लॉन्च किया जा रहा है...";
 COPYING_BUNDLE = "एप्लिकेशन बंडल कॉपी किया जा रहा है...";
 DECRYPTING_BINARY = "बाइनरी डिक्रिप्ट की जा रही है...";
+SAVING_APP_BUNDLE = "Saving app bundle...";
 DECRYPTION_COMPLETED = "डिक्रिप्शन पूर्ण हुआ!";
 BUILDING_IPA = "IPA बनाया जा रहा है... (इसमें एक मिनट लग सकता है)";
 

--- a/Resources/hi.lproj/Localizable.strings
+++ b/Resources/hi.lproj/Localizable.strings
@@ -16,6 +16,7 @@ DECRYPTED_BINARIES = "डिक्रिप्ट किए गए बाइन�
 
 DECRYPTION_PROMPT = "क्या आप %@ को डिक्रिप्ट करना चाहते हैं?";
 MAIN_BINARY_ONLY = "केवल मुख्य बाइनरी";
+APP_BUNDLE_ONLY = "App Bundle Only";
 FULL_IPA = "पूर्ण IPA";
 
 LAUNCHING_APPLICATION = "एप्लिकेशन लॉन्च किया जा रहा है...";

--- a/Resources/hr.lproj/Localizable.strings
+++ b/Resources/hr.lproj/Localizable.strings
@@ -22,6 +22,7 @@ FULL_IPA = "Cijeli IPA";
 LAUNCHING_APPLICATION = "Pokretanje aplikacije...";
 COPYING_BUNDLE = "Kopiranje paketa aplikacije...";
 DECRYPTING_BINARY = "Dekriptiranje binara...";
+SAVING_APP_BUNDLE = "Saving app bundle...";
 DECRYPTION_COMPLETED = "Dekriptiranje završeno!";
 BUILDING_IPA = "Izrada IPA-a... (Ovo može potrajati minutu)";
 

--- a/Resources/hr.lproj/Localizable.strings
+++ b/Resources/hr.lproj/Localizable.strings
@@ -12,6 +12,7 @@ DECRYPT_APPS = "Dekriptiraj aplikacije";
 DECRYPTED_FILES = "Dekriptirane datoteke";
 
 DECRYPTED_IPAS = "Dekriptirani IPA-ovi (%lu)";
+DECRYPTED_APP_BUNDLES = "Decrypted App Bundles (%lu)";
 DECRYPTED_BINARIES = "Dekriptirani binarici (%lu)";
 
 DECRYPTION_PROMPT = "Želite li dekriptirati %@?";
@@ -32,4 +33,5 @@ MANUAL_ENTRY_TITLE = "Ručno unos identifikatora paketa";
 MANUAL_ENTRY_SUBTITLE = "Unesite identifikator paketa aplikacije koju želite dekriptirati.";
 
 SHOW_IN_FILZA = "Prikaži u Filza";
+COPY_PATH = "Copy Path";
 SHOW_IN_FILES = "Prikaži u Datotekama";

--- a/Resources/hr.lproj/Localizable.strings
+++ b/Resources/hr.lproj/Localizable.strings
@@ -16,6 +16,7 @@ DECRYPTED_BINARIES = "Dekriptirani binarici (%lu)";
 
 DECRYPTION_PROMPT = "Želite li dekriptirati %@?";
 MAIN_BINARY_ONLY = "Samo glavni binar";
+APP_BUNDLE_ONLY = "App Bundle Only";
 FULL_IPA = "Cijeli IPA";
 
 LAUNCHING_APPLICATION = "Pokretanje aplikacije...";

--- a/Resources/hu.lproj/Localizable.strings
+++ b/Resources/hu.lproj/Localizable.strings
@@ -16,6 +16,7 @@ DECRYPTED_BINARIES = "Visszafejtett binárisok (%lu)";
 
 DECRYPTION_PROMPT = "Szeretné visszafejteni ezt: %@?";
 MAIN_BINARY_ONLY = "Csak fő bináris";
+APP_BUNDLE_ONLY = "App Bundle Only";
 FULL_IPA = "Teljes IPA";
 
 LAUNCHING_APPLICATION = "Alkalmazás indítása...";

--- a/Resources/hu.lproj/Localizable.strings
+++ b/Resources/hu.lproj/Localizable.strings
@@ -22,6 +22,7 @@ FULL_IPA = "Teljes IPA";
 LAUNCHING_APPLICATION = "Alkalmazás indítása...";
 COPYING_BUNDLE = "Alkalmazáscsomag másolása...";
 DECRYPTING_BINARY = "Bináris visszafejtése...";
+SAVING_APP_BUNDLE = "Saving app bundle...";
 DECRYPTION_COMPLETED = "Visszafejtés befejezve!";
 BUILDING_IPA = "IPA készítése... (Ez eltarthat egy percig)";
 

--- a/Resources/hu.lproj/Localizable.strings
+++ b/Resources/hu.lproj/Localizable.strings
@@ -12,6 +12,7 @@ DECRYPT_APPS = "Alkalmazások visszafejtése";
 DECRYPTED_FILES = "Visszafejtett fájlok";
 
 DECRYPTED_IPAS = "Visszafejtett IPA-k (%lu)";
+DECRYPTED_APP_BUNDLES = "Decrypted App Bundles (%lu)";
 DECRYPTED_BINARIES = "Visszafejtett binárisok (%lu)";
 
 DECRYPTION_PROMPT = "Szeretné visszafejteni ezt: %@?";
@@ -32,4 +33,5 @@ MANUAL_ENTRY_TITLE = "Kézi csomagazonosító";
 MANUAL_ENTRY_SUBTITLE = "Adja meg a visszafejtendő alkalmazás csomagazonosítóját.";
 
 SHOW_IN_FILZA = "Megjelenítés Filzában";
+COPY_PATH = "Copy Path";
 SHOW_IN_FILES = "Megjelenítés a Fájlokban";

--- a/Resources/id.lproj/Localizable.strings
+++ b/Resources/id.lproj/Localizable.strings
@@ -12,6 +12,7 @@ DECRYPT_APPS = "Dekripsi Aplikasi";
 DECRYPTED_FILES = "Berkas yang Didekripsi";
 
 DECRYPTED_IPAS = "IPA yang Didekripsi (%lu)";
+DECRYPTED_APP_BUNDLES = "Decrypted App Bundles (%lu)";
 DECRYPTED_BINARIES = "Biner yang Didekripsi (%lu)";
 
 DECRYPTION_PROMPT = "Apakah Anda ingin mendekripsi %@?";
@@ -32,4 +33,5 @@ MANUAL_ENTRY_TITLE = "Masukkan Bundle Identifier Secara Manual";
 MANUAL_ENTRY_SUBTITLE = "Masukkan bundle identifier aplikasi yang ingin Anda dekripsi.";
 
 SHOW_IN_FILZA = "Tampilkan di Filza";
+COPY_PATH = "Copy Path";
 SHOW_IN_FILES = "Tampilkan di File";

--- a/Resources/id.lproj/Localizable.strings
+++ b/Resources/id.lproj/Localizable.strings
@@ -16,6 +16,7 @@ DECRYPTED_BINARIES = "Biner yang Didekripsi (%lu)";
 
 DECRYPTION_PROMPT = "Apakah Anda ingin mendekripsi %@?";
 MAIN_BINARY_ONLY = "Hanya Biner Utama";
+APP_BUNDLE_ONLY = "App Bundle Only";
 FULL_IPA = "IPA Lengkap";
 
 LAUNCHING_APPLICATION = "Meluncurkan Aplikasi...";

--- a/Resources/id.lproj/Localizable.strings
+++ b/Resources/id.lproj/Localizable.strings
@@ -22,6 +22,7 @@ FULL_IPA = "IPA Lengkap";
 LAUNCHING_APPLICATION = "Meluncurkan Aplikasi...";
 COPYING_BUNDLE = "Menyalin Bundle Aplikasi...";
 DECRYPTING_BINARY = "Mendekripsi Biner...";
+SAVING_APP_BUNDLE = "Saving app bundle...";
 DECRYPTION_COMPLETED = "Dekripsi Selesai!";
 BUILDING_IPA = "Membangun IPA... (Ini mungkin memakan waktu satu menit)";
 

--- a/Resources/it.lproj/Localizable.strings
+++ b/Resources/it.lproj/Localizable.strings
@@ -16,6 +16,7 @@ DECRYPTED_BINARIES = "Binari decriptati (%lu)";
 
 DECRYPTION_PROMPT = "Vuoi decriptare %@?";
 MAIN_BINARY_ONLY = "Solo binario principale";
+APP_BUNDLE_ONLY = "App Bundle Only";
 FULL_IPA = "IPA completo";
 
 LAUNCHING_APPLICATION = "Avvio dell'applicazione...";

--- a/Resources/it.lproj/Localizable.strings
+++ b/Resources/it.lproj/Localizable.strings
@@ -12,6 +12,7 @@ DECRYPT_APPS = "Decripta app";
 DECRYPTED_FILES = "File decriptati";
 
 DECRYPTED_IPAS = "IPA decriptati (%lu)";
+DECRYPTED_APP_BUNDLES = "Decrypted App Bundles (%lu)";
 DECRYPTED_BINARIES = "Binari decriptati (%lu)";
 
 DECRYPTION_PROMPT = "Vuoi decriptare %@?";
@@ -32,4 +33,5 @@ MANUAL_ENTRY_TITLE = "Identificatore bundle manuale";
 MANUAL_ENTRY_SUBTITLE = "Inserisci l'identificatore bundle dell'applicazione che vuoi decriptare.";
 
 SHOW_IN_FILZA = "Mostra in Filza";
+COPY_PATH = "Copy Path";
 SHOW_IN_FILES = "Mostra in File";

--- a/Resources/it.lproj/Localizable.strings
+++ b/Resources/it.lproj/Localizable.strings
@@ -22,6 +22,7 @@ FULL_IPA = "IPA completo";
 LAUNCHING_APPLICATION = "Avvio dell'applicazione...";
 COPYING_BUNDLE = "Copia del bundle dell'applicazione...";
 DECRYPTING_BINARY = "Decriptazione del binario...";
+SAVING_APP_BUNDLE = "Saving app bundle...";
 DECRYPTION_COMPLETED = "Decriptazione completata!";
 BUILDING_IPA = "Creazione IPA... (Potrebbe richiedere un minuto)";
 

--- a/Resources/ja.lproj/Localizable.strings
+++ b/Resources/ja.lproj/Localizable.strings
@@ -22,6 +22,7 @@ FULL_IPA = "フルIPA";
 LAUNCHING_APPLICATION = "アプリを起動中...";
 COPYING_BUNDLE = "アプリバンドルをコピー中...";
 DECRYPTING_BINARY = "バイナリを復号中...";
+SAVING_APP_BUNDLE = "Saving app bundle...";
 DECRYPTION_COMPLETED = "復号完了！";
 BUILDING_IPA = "IPAを作成中...（しばらくお待ちください）";
 

--- a/Resources/ja.lproj/Localizable.strings
+++ b/Resources/ja.lproj/Localizable.strings
@@ -16,6 +16,7 @@ DECRYPTED_BINARIES = "復号済みバイナリ（%lu）";
 
 DECRYPTION_PROMPT = "%@を復号しますか？";
 MAIN_BINARY_ONLY = "メインバイナリのみ";
+APP_BUNDLE_ONLY = "App Bundle Only";
 FULL_IPA = "フルIPA";
 
 LAUNCHING_APPLICATION = "アプリを起動中...";

--- a/Resources/ja.lproj/Localizable.strings
+++ b/Resources/ja.lproj/Localizable.strings
@@ -12,6 +12,7 @@ DECRYPT_APPS = "アプリを復号";
 DECRYPTED_FILES = "復号済みファイル";
 
 DECRYPTED_IPAS = "復号済みIPA（%lu）";
+DECRYPTED_APP_BUNDLES = "Decrypted App Bundles (%lu)";
 DECRYPTED_BINARIES = "復号済みバイナリ（%lu）";
 
 DECRYPTION_PROMPT = "%@を復号しますか？";
@@ -32,4 +33,5 @@ MANUAL_ENTRY_TITLE = "バンドルIDを手動入力";
 MANUAL_ENTRY_SUBTITLE = "復号したいアプリのバンドルIDを入力してください。";
 
 SHOW_IN_FILZA = "Filzaで表示";
+COPY_PATH = "Copy Path";
 SHOW_IN_FILES = "ファイルで表示";

--- a/Resources/ko.lproj/Localizable.strings
+++ b/Resources/ko.lproj/Localizable.strings
@@ -22,6 +22,7 @@ FULL_IPA = "전체 IPA";
 LAUNCHING_APPLICATION = "애플리케이션 실행 중...";
 COPYING_BUNDLE = "애플리케이션 번들 복사 중...";
 DECRYPTING_BINARY = "바이너리 복호화 중...";
+SAVING_APP_BUNDLE = "Saving app bundle...";
 DECRYPTION_COMPLETED = "복호화 완료!";
 BUILDING_IPA = "IPA 생성 중... (잠시만 기다려주세요)";
 

--- a/Resources/ko.lproj/Localizable.strings
+++ b/Resources/ko.lproj/Localizable.strings
@@ -16,6 +16,7 @@ DECRYPTED_BINARIES = "복호화된 바이너리 (%lu)";
 
 DECRYPTION_PROMPT = "%@을(를) 복호화하시겠습니까?";
 MAIN_BINARY_ONLY = "메인 바이너리만";
+APP_BUNDLE_ONLY = "App Bundle Only";
 FULL_IPA = "전체 IPA";
 
 LAUNCHING_APPLICATION = "애플리케이션 실행 중...";

--- a/Resources/ko.lproj/Localizable.strings
+++ b/Resources/ko.lproj/Localizable.strings
@@ -12,6 +12,7 @@ DECRYPT_APPS = "앱 복호화";
 DECRYPTED_FILES = "복호화된 파일";
 
 DECRYPTED_IPAS = "복호화된 IPA (%lu)";
+DECRYPTED_APP_BUNDLES = "Decrypted App Bundles (%lu)";
 DECRYPTED_BINARIES = "복호화된 바이너리 (%lu)";
 
 DECRYPTION_PROMPT = "%@을(를) 복호화하시겠습니까?";
@@ -32,4 +33,5 @@ MANUAL_ENTRY_TITLE = "번들 식별자 수동 입력";
 MANUAL_ENTRY_SUBTITLE = "복호화할 애플리케이션의 번들 식별자를 입력하세요.";
 
 SHOW_IN_FILZA = "Filza에서 보기";
+COPY_PATH = "Copy Path";
 SHOW_IN_FILES = "파일에서 보기";

--- a/Resources/ms.lproj/Localizable.strings
+++ b/Resources/ms.lproj/Localizable.strings
@@ -22,6 +22,7 @@ FULL_IPA = "IPA Penuh";
 LAUNCHING_APPLICATION = "Sedang Melancarkan Aplikasi...";
 COPYING_BUNDLE = "Sedang Menyalin Bundle Aplikasi...";
 DECRYPTING_BINARY = "Sedang Menyahsulit Binari...";
+SAVING_APP_BUNDLE = "Saving app bundle...";
 DECRYPTION_COMPLETED = "Nyahsulitan Selesai!";
 BUILDING_IPA = "Sedang Membina IPA... (Ini mungkin mengambil masa sebentar)";
 

--- a/Resources/ms.lproj/Localizable.strings
+++ b/Resources/ms.lproj/Localizable.strings
@@ -16,6 +16,7 @@ DECRYPTED_BINARIES = "Binari yang Telah Disahsulit (%lu)";
 
 DECRYPTION_PROMPT = "Adakah anda ingin menyahsulit %@?";
 MAIN_BINARY_ONLY = "Hanya Binari Utama";
+APP_BUNDLE_ONLY = "App Bundle Only";
 FULL_IPA = "IPA Penuh";
 
 LAUNCHING_APPLICATION = "Sedang Melancarkan Aplikasi...";

--- a/Resources/ms.lproj/Localizable.strings
+++ b/Resources/ms.lproj/Localizable.strings
@@ -12,6 +12,7 @@ DECRYPT_APPS = "Nyahsulit Aplikasi";
 DECRYPTED_FILES = "Fail yang Telah Disahsulit";
 
 DECRYPTED_IPAS = "IPA yang Telah Disahsulit (%lu)";
+DECRYPTED_APP_BUNDLES = "Decrypted App Bundles (%lu)";
 DECRYPTED_BINARIES = "Binari yang Telah Disahsulit (%lu)";
 
 DECRYPTION_PROMPT = "Adakah anda ingin menyahsulit %@?";
@@ -32,4 +33,5 @@ MANUAL_ENTRY_TITLE = "Pengenal Bundle Manual";
 MANUAL_ENTRY_SUBTITLE = "Masukkan pengenal bundle aplikasi yang anda ingin nyahsulit.";
 
 SHOW_IN_FILZA = "Tunjuk dalam Filza";
+COPY_PATH = "Copy Path";
 SHOW_IN_FILES = "Tunjuk dalam Fail";

--- a/Resources/nb.lproj/Localizable.strings
+++ b/Resources/nb.lproj/Localizable.strings
@@ -12,6 +12,7 @@ DECRYPT_APPS = "Dekrypter apper";
 DECRYPTED_FILES = "Dekrypterte filer";
 
 DECRYPTED_IPAS = "Dekrypterte IPA-filer (%lu)";
+DECRYPTED_APP_BUNDLES = "Decrypted App Bundles (%lu)";
 DECRYPTED_BINARIES = "Dekrypterte binærfiler (%lu)";
 
 DECRYPTION_PROMPT = "Vil du dekryptere %@?";
@@ -32,4 +33,5 @@ MANUAL_ENTRY_TITLE = "Manuell buntidentifikator";
 MANUAL_ENTRY_SUBTITLE = "Skriv inn buntidentifikatoren til applikasjonen du vil dekryptere.";
 
 SHOW_IN_FILZA = "Vis i Filza";
+COPY_PATH = "Copy Path";
 SHOW_IN_FILES = "Vis i Filer";

--- a/Resources/nb.lproj/Localizable.strings
+++ b/Resources/nb.lproj/Localizable.strings
@@ -16,6 +16,7 @@ DECRYPTED_BINARIES = "Dekrypterte binærfiler (%lu)";
 
 DECRYPTION_PROMPT = "Vil du dekryptere %@?";
 MAIN_BINARY_ONLY = "Kun hovedbinær";
+APP_BUNDLE_ONLY = "App Bundle Only";
 FULL_IPA = "Full IPA";
 
 LAUNCHING_APPLICATION = "Starter applikasjon...";

--- a/Resources/nb.lproj/Localizable.strings
+++ b/Resources/nb.lproj/Localizable.strings
@@ -22,6 +22,7 @@ FULL_IPA = "Full IPA";
 LAUNCHING_APPLICATION = "Starter applikasjon...";
 COPYING_BUNDLE = "Kopierer applikasjonspakke...";
 DECRYPTING_BINARY = "Dekrypterer binærfil...";
+SAVING_APP_BUNDLE = "Saving app bundle...";
 DECRYPTION_COMPLETED = "Dekryptering fullført!";
 BUILDING_IPA = "Bygger IPA... (Dette kan ta et minutt)";
 

--- a/Resources/nl.lproj/Localizable.strings
+++ b/Resources/nl.lproj/Localizable.strings
@@ -12,6 +12,7 @@ DECRYPT_APPS = "Apps ontsleutelen";
 DECRYPTED_FILES = "Ontsleutelde bestanden";
 
 DECRYPTED_IPAS = "Ontsleutelde IPA's (%lu)";
+DECRYPTED_APP_BUNDLES = "Decrypted App Bundles (%lu)";
 DECRYPTED_BINARIES = "Ontsleutelde binaries (%lu)";
 
 DECRYPTION_PROMPT = "Wil je %@ ontsleutelen?";
@@ -32,4 +33,5 @@ MANUAL_ENTRY_TITLE = "Handmatige bundle-ID";
 MANUAL_ENTRY_SUBTITLE = "Voer de bundle-ID in van de app die je wilt ontsleutelen.";
 
 SHOW_IN_FILZA = "Toon in Filza";
+COPY_PATH = "Copy Path";
 SHOW_IN_FILES = "Toon in Bestanden";

--- a/Resources/nl.lproj/Localizable.strings
+++ b/Resources/nl.lproj/Localizable.strings
@@ -16,6 +16,7 @@ DECRYPTED_BINARIES = "Ontsleutelde binaries (%lu)";
 
 DECRYPTION_PROMPT = "Wil je %@ ontsleutelen?";
 MAIN_BINARY_ONLY = "Alleen hoofd-binary";
+APP_BUNDLE_ONLY = "App Bundle Only";
 FULL_IPA = "Volledige IPA";
 
 LAUNCHING_APPLICATION = "Applicatie wordt gestart...";

--- a/Resources/nl.lproj/Localizable.strings
+++ b/Resources/nl.lproj/Localizable.strings
@@ -22,6 +22,7 @@ FULL_IPA = "Volledige IPA";
 LAUNCHING_APPLICATION = "Applicatie wordt gestart...";
 COPYING_BUNDLE = "Applicatiebundel wordt gekopieerd...";
 DECRYPTING_BINARY = "Binary wordt ontsleuteld...";
+SAVING_APP_BUNDLE = "Saving app bundle...";
 DECRYPTION_COMPLETED = "Ontsleuteling voltooid!";
 BUILDING_IPA = "IPA wordt gebouwd... (Dit kan een minuut duren)";
 

--- a/Resources/pl.lproj/Localizable.strings
+++ b/Resources/pl.lproj/Localizable.strings
@@ -22,6 +22,7 @@ FULL_IPA = "Pełne IPA";
 LAUNCHING_APPLICATION = "Uruchamianie aplikacji...";
 COPYING_BUNDLE = "Kopiowanie pakietu aplikacji...";
 DECRYPTING_BINARY = "Odszyfrowywanie pliku binarnego...";
+SAVING_APP_BUNDLE = "Saving app bundle...";
 DECRYPTION_COMPLETED = "Odszyfrowywanie zakończone!";
 BUILDING_IPA = "Tworzenie IPA... (To może chwilę potrwać)";
 

--- a/Resources/pl.lproj/Localizable.strings
+++ b/Resources/pl.lproj/Localizable.strings
@@ -16,6 +16,7 @@ DECRYPTED_BINARIES = "Odszyfrowane binaria (%lu)";
 
 DECRYPTION_PROMPT = "Czy chcesz odszyfrować %@?";
 MAIN_BINARY_ONLY = "Tylko główny plik binarny";
+APP_BUNDLE_ONLY = "App Bundle Only";
 FULL_IPA = "Pełne IPA";
 
 LAUNCHING_APPLICATION = "Uruchamianie aplikacji...";

--- a/Resources/pl.lproj/Localizable.strings
+++ b/Resources/pl.lproj/Localizable.strings
@@ -12,6 +12,7 @@ DECRYPT_APPS = "Odszyfruj aplikacje";
 DECRYPTED_FILES = "Odszyfrowane pliki";
 
 DECRYPTED_IPAS = "Odszyfrowane IPA (%lu)";
+DECRYPTED_APP_BUNDLES = "Decrypted App Bundles (%lu)";
 DECRYPTED_BINARIES = "Odszyfrowane binaria (%lu)";
 
 DECRYPTION_PROMPT = "Czy chcesz odszyfrować %@?";
@@ -32,4 +33,5 @@ MANUAL_ENTRY_TITLE = "Ręczny identyfikator pakietu";
 MANUAL_ENTRY_SUBTITLE = "Wprowadź identyfikator pakietu aplikacji, którą chcesz odszyfrować.";
 
 SHOW_IN_FILZA = "Pokaż w Filza";
+COPY_PATH = "Copy Path";
 SHOW_IN_FILES = "Pokaż w Plikach";

--- a/Resources/pt.lproj/Localizable.strings
+++ b/Resources/pt.lproj/Localizable.strings
@@ -12,6 +12,7 @@ DECRYPT_APPS = "Descriptografar Apps";
 DECRYPTED_FILES = "Arquivos Descriptografados";
 
 DECRYPTED_IPAS = "IPAs Descriptografados (%lu)";
+DECRYPTED_APP_BUNDLES = "Decrypted App Bundles (%lu)";
 DECRYPTED_BINARIES = "Binários Descriptografados (%lu)";
 
 DECRYPTION_PROMPT = "Você deseja descriptografar %@?";
@@ -32,4 +33,5 @@ MANUAL_ENTRY_TITLE = "Identificador do Pacote Manual";
 MANUAL_ENTRY_SUBTITLE = "Digite o identificador do pacote do aplicativo que você deseja descriptografar.";
 
 SHOW_IN_FILZA = "Mostrar no Filza";
+COPY_PATH = "Copy Path";
 SHOW_IN_FILES = "Mostrar em Arquivos";

--- a/Resources/pt.lproj/Localizable.strings
+++ b/Resources/pt.lproj/Localizable.strings
@@ -16,6 +16,7 @@ DECRYPTED_BINARIES = "Binários Descriptografados (%lu)";
 
 DECRYPTION_PROMPT = "Você deseja descriptografar %@?";
 MAIN_BINARY_ONLY = "Apenas Binário Principal";
+APP_BUNDLE_ONLY = "App Bundle Only";
 FULL_IPA = "IPA Completo";
 
 LAUNCHING_APPLICATION = "Iniciando Aplicativo...";

--- a/Resources/pt.lproj/Localizable.strings
+++ b/Resources/pt.lproj/Localizable.strings
@@ -22,6 +22,7 @@ FULL_IPA = "IPA Completo";
 LAUNCHING_APPLICATION = "Iniciando Aplicativo...";
 COPYING_BUNDLE = "Copiando Pacote do Aplicativo...";
 DECRYPTING_BINARY = "Descriptografando Binário...";
+SAVING_APP_BUNDLE = "Saving app bundle...";
 DECRYPTION_COMPLETED = "Descriptografia Concluída!";
 BUILDING_IPA = "Construindo IPA... (Isso pode levar um minuto)";
 

--- a/Resources/ro.lproj/Localizable.strings
+++ b/Resources/ro.lproj/Localizable.strings
@@ -12,6 +12,7 @@ DECRYPT_APPS = "Decriptează aplicații";
 DECRYPTED_FILES = "Fișiere decriptate";
 
 DECRYPTED_IPAS = "IPA-uri decriptate (%lu)";
+DECRYPTED_APP_BUNDLES = "Decrypted App Bundles (%lu)";
 DECRYPTED_BINARIES = "Binaruri decriptate (%lu)";
 
 DECRYPTION_PROMPT = "Doriți să decriptați %@?";
@@ -32,4 +33,5 @@ MANUAL_ENTRY_TITLE = "Identificator de pachet manual";
 MANUAL_ENTRY_SUBTITLE = "Introduceți identificatorul de pachet al aplicației pe care doriți să o decriptați.";
 
 SHOW_IN_FILZA = "Arată în Filza";
+COPY_PATH = "Copy Path";
 SHOW_IN_FILES = "Arată în Fișiere";

--- a/Resources/ro.lproj/Localizable.strings
+++ b/Resources/ro.lproj/Localizable.strings
@@ -22,6 +22,7 @@ FULL_IPA = "IPA complet";
 LAUNCHING_APPLICATION = "Se lansează aplicația...";
 COPYING_BUNDLE = "Se copiază pachetul aplicației...";
 DECRYPTING_BINARY = "Se decriptează binarul...";
+SAVING_APP_BUNDLE = "Saving app bundle...";
 DECRYPTION_COMPLETED = "Decriptare finalizată!";
 BUILDING_IPA = "Se creează IPA... (Acest proces poate dura un minut)";
 

--- a/Resources/ro.lproj/Localizable.strings
+++ b/Resources/ro.lproj/Localizable.strings
@@ -16,6 +16,7 @@ DECRYPTED_BINARIES = "Binaruri decriptate (%lu)";
 
 DECRYPTION_PROMPT = "Doriți să decriptați %@?";
 MAIN_BINARY_ONLY = "Doar binarul principal";
+APP_BUNDLE_ONLY = "App Bundle Only";
 FULL_IPA = "IPA complet";
 
 LAUNCHING_APPLICATION = "Se lansează aplicația...";

--- a/Resources/ru.lproj/Localizable.strings
+++ b/Resources/ru.lproj/Localizable.strings
@@ -12,6 +12,7 @@ DECRYPT_APPS = "Расшифровать приложения";
 DECRYPTED_FILES = "Расшифрованные файлы";
 
 DECRYPTED_IPAS = "Расшифрованные IPA (%lu)";
+DECRYPTED_APP_BUNDLES = "Decrypted App Bundles (%lu)";
 DECRYPTED_BINARIES = "Расшифрованные бинарные файлы (%lu)";
 
 DECRYPTION_PROMPT = "Вы хотите расшифровать %@?";
@@ -32,4 +33,5 @@ MANUAL_ENTRY_TITLE = "Ввод идентификатора пакета вру�
 MANUAL_ENTRY_SUBTITLE = "Введите идентификатор пакета приложения, которое вы хотите расшифровать.";
 
 SHOW_IN_FILZA = "Показать в Filza";
+COPY_PATH = "Copy Path";
 SHOW_IN_FILES = "Показать в Файлах";

--- a/Resources/ru.lproj/Localizable.strings
+++ b/Resources/ru.lproj/Localizable.strings
@@ -16,6 +16,7 @@ DECRYPTED_BINARIES = "Расшифрованные бинарные файлы (
 
 DECRYPTION_PROMPT = "Вы хотите расшифровать %@?";
 MAIN_BINARY_ONLY = "Только основной бинарный файл";
+APP_BUNDLE_ONLY = "App Bundle Only";
 FULL_IPA = "Полный IPA";
 
 LAUNCHING_APPLICATION = "Запуск приложения...";

--- a/Resources/ru.lproj/Localizable.strings
+++ b/Resources/ru.lproj/Localizable.strings
@@ -22,6 +22,7 @@ FULL_IPA = "Полный IPA";
 LAUNCHING_APPLICATION = "Запуск приложения...";
 COPYING_BUNDLE = "Копирование пакета приложения...";
 DECRYPTING_BINARY = "Расшифровка бинарного файла...";
+SAVING_APP_BUNDLE = "Saving app bundle...";
 DECRYPTION_COMPLETED = "Расшифровка завершена!";
 BUILDING_IPA = "Создание IPA... (Это может занять минуту)";
 

--- a/Resources/sk.lproj/Localizable.strings
+++ b/Resources/sk.lproj/Localizable.strings
@@ -12,6 +12,7 @@ DECRYPT_APPS = "Dešifrovať aplikácie";
 DECRYPTED_FILES = "Dešifrované súbory";
 
 DECRYPTED_IPAS = "Dešifrované IPA súbory (%lu)";
+DECRYPTED_APP_BUNDLES = "Decrypted App Bundles (%lu)";
 DECRYPTED_BINARIES = "Dešifrované binárky (%lu)";
 
 DECRYPTION_PROMPT = "Chcete dešifrovať %@?";
@@ -32,4 +33,5 @@ MANUAL_ENTRY_TITLE = "Manuálne zadať identifikátor balíka";
 MANUAL_ENTRY_SUBTITLE = "Zadajte identifikátor balíka aplikácie, ktorú chcete dešifrovať.";
 
 SHOW_IN_FILZA = "Zobraziť vo Filza";
+COPY_PATH = "Copy Path";
 SHOW_IN_FILES = "Zobraziť v Súboroch";

--- a/Resources/sk.lproj/Localizable.strings
+++ b/Resources/sk.lproj/Localizable.strings
@@ -22,6 +22,7 @@ FULL_IPA = "Celé IPA";
 LAUNCHING_APPLICATION = "Spúšťanie aplikácie...";
 COPYING_BUNDLE = "Kopírovanie balíka aplikácie...";
 DECRYPTING_BINARY = "Dešifrovanie binárky...";
+SAVING_APP_BUNDLE = "Saving app bundle...";
 DECRYPTION_COMPLETED = "Dešifrovanie dokončené!";
 BUILDING_IPA = "Vytváranie IPA... (Môže to chvíľu trvať)";
 

--- a/Resources/sk.lproj/Localizable.strings
+++ b/Resources/sk.lproj/Localizable.strings
@@ -16,6 +16,7 @@ DECRYPTED_BINARIES = "Dešifrované binárky (%lu)";
 
 DECRYPTION_PROMPT = "Chcete dešifrovať %@?";
 MAIN_BINARY_ONLY = "Len hlavná binárka";
+APP_BUNDLE_ONLY = "App Bundle Only";
 FULL_IPA = "Celé IPA";
 
 LAUNCHING_APPLICATION = "Spúšťanie aplikácie...";

--- a/Resources/sv.lproj/Localizable.strings
+++ b/Resources/sv.lproj/Localizable.strings
@@ -16,6 +16,7 @@ DECRYPTED_BINARIES = "Dekrypterade binärer (%lu)";
 
 DECRYPTION_PROMPT = "Vill du dekryptera %@?";
 MAIN_BINARY_ONLY = "Endast huvudbinär";
+APP_BUNDLE_ONLY = "App Bundle Only";
 FULL_IPA = "Fullständig IPA";
 
 LAUNCHING_APPLICATION = "Startar applikation...";

--- a/Resources/sv.lproj/Localizable.strings
+++ b/Resources/sv.lproj/Localizable.strings
@@ -12,6 +12,7 @@ DECRYPT_APPS = "Dekryptera appar";
 DECRYPTED_FILES = "Dekrypterade filer";
 
 DECRYPTED_IPAS = "Dekrypterade IPA-filer (%lu)";
+DECRYPTED_APP_BUNDLES = "Decrypted App Bundles (%lu)";
 DECRYPTED_BINARIES = "Dekrypterade binärer (%lu)";
 
 DECRYPTION_PROMPT = "Vill du dekryptera %@?";
@@ -32,4 +33,5 @@ MANUAL_ENTRY_TITLE = "Manuell paketidentifierare";
 MANUAL_ENTRY_SUBTITLE = "Ange paketidentifieraren för appen du vill dekryptera.";
 
 SHOW_IN_FILZA = "Visa i Filza";
+COPY_PATH = "Copy Path";
 SHOW_IN_FILES = "Visa i Filer";

--- a/Resources/sv.lproj/Localizable.strings
+++ b/Resources/sv.lproj/Localizable.strings
@@ -22,6 +22,7 @@ FULL_IPA = "Fullständig IPA";
 LAUNCHING_APPLICATION = "Startar applikation...";
 COPYING_BUNDLE = "Kopierar applikationspaket...";
 DECRYPTING_BINARY = "Dekrypterar binär...";
+SAVING_APP_BUNDLE = "Saving app bundle...";
 DECRYPTION_COMPLETED = "Dekryptering klar!";
 BUILDING_IPA = "Bygger IPA... (Detta kan ta en minut)";
 

--- a/Resources/th.lproj/Localizable.strings
+++ b/Resources/th.lproj/Localizable.strings
@@ -12,6 +12,7 @@ DECRYPT_APPS = "ถอดรหัสแอป";
 DECRYPTED_FILES = "ไฟล์ที่ถอดรหัสแล้ว";
 
 DECRYPTED_IPAS = "IPAs ที่ถอดรหัสแล้ว (%lu)";
+DECRYPTED_APP_BUNDLES = "Decrypted App Bundles (%lu)";
 DECRYPTED_BINARIES = "ไฟล์ไบนารีที่ถอดรหัสแล้ว (%lu)";
 
 DECRYPTION_PROMPT = "คุณต้องการถอดรหัส %@ หรือไม่?";
@@ -32,4 +33,5 @@ MANUAL_ENTRY_TITLE = "ป้อนรหัสบันเดิลด้วย�
 MANUAL_ENTRY_SUBTITLE = "กรอกรหัสบันเดิลของแอปพลิเคชันที่คุณต้องการถอดรหัส";
 
 SHOW_IN_FILZA = "แสดงใน Filza";
+COPY_PATH = "Copy Path";
 SHOW_IN_FILES = "แสดงในไฟล์";

--- a/Resources/th.lproj/Localizable.strings
+++ b/Resources/th.lproj/Localizable.strings
@@ -16,6 +16,7 @@ DECRYPTED_BINARIES = "ไฟล์ไบนารีที่ถอดรหั�
 
 DECRYPTION_PROMPT = "คุณต้องการถอดรหัส %@ หรือไม่?";
 MAIN_BINARY_ONLY = "เฉพาะไฟล์ไบนารีหลัก";
+APP_BUNDLE_ONLY = "App Bundle Only";
 FULL_IPA = "IPA ทั้งหมด";
 
 LAUNCHING_APPLICATION = "กำลังเปิดแอปพลิเคชัน...";

--- a/Resources/th.lproj/Localizable.strings
+++ b/Resources/th.lproj/Localizable.strings
@@ -22,6 +22,7 @@ FULL_IPA = "IPA ทั้งหมด";
 LAUNCHING_APPLICATION = "กำลังเปิดแอปพลิเคชัน...";
 COPYING_BUNDLE = "กำลังคัดลอกชุดแอปพลิเคชัน...";
 DECRYPTING_BINARY = "กำลังถอดรหัสไบนารี...";
+SAVING_APP_BUNDLE = "Saving app bundle...";
 DECRYPTION_COMPLETED = "ถอดรหัสเสร็จสิ้น!";
 BUILDING_IPA = "กำลังสร้างไฟล์ IPA... (อาจใช้เวลาสักครู่)";
 

--- a/Resources/tr.lproj/Localizable.strings
+++ b/Resources/tr.lproj/Localizable.strings
@@ -16,6 +16,7 @@ DECRYPTED_BINARIES = "Şifresi Çözülmüş İkili Dosyalar (%lu)";
 
 DECRYPTION_PROMPT = "%@ uygulamasının şifresini çözmek istiyor musunuz?";
 MAIN_BINARY_ONLY = "Sadece Ana İkili Dosya";
+APP_BUNDLE_ONLY = "App Bundle Only";
 FULL_IPA = "Tüm IPA";
 
 LAUNCHING_APPLICATION = "Uygulama Başlatılıyor...";

--- a/Resources/tr.lproj/Localizable.strings
+++ b/Resources/tr.lproj/Localizable.strings
@@ -12,6 +12,7 @@ DECRYPT_APPS = "Uygulamaların Şifresini Çöz";
 DECRYPTED_FILES = "Şifresi Çözülmüş Dosyalar";
 
 DECRYPTED_IPAS = "Şifresi Çözülmüş IPA'lar (%lu)";
+DECRYPTED_APP_BUNDLES = "Decrypted App Bundles (%lu)";
 DECRYPTED_BINARIES = "Şifresi Çözülmüş İkili Dosyalar (%lu)";
 
 DECRYPTION_PROMPT = "%@ uygulamasının şifresini çözmek istiyor musunuz?";
@@ -32,4 +33,5 @@ MANUAL_ENTRY_TITLE = "Manuel Paket Tanımlayıcı";
 MANUAL_ENTRY_SUBTITLE = "Şifresini çözmek istediğiniz uygulamanın paket tanımlayıcısını girin.";
 
 SHOW_IN_FILZA = "Filza'da Göster";
+COPY_PATH = "Copy Path";
 SHOW_IN_FILES = "Dosyalar'da Göster";

--- a/Resources/tr.lproj/Localizable.strings
+++ b/Resources/tr.lproj/Localizable.strings
@@ -22,6 +22,7 @@ FULL_IPA = "Tüm IPA";
 LAUNCHING_APPLICATION = "Uygulama Başlatılıyor...";
 COPYING_BUNDLE = "Uygulama Paketi Kopyalanıyor...";
 DECRYPTING_BINARY = "İkili Dosya Şifresi Çözülüyor...";
+SAVING_APP_BUNDLE = "Saving app bundle...";
 DECRYPTION_COMPLETED = "Şifre Çözme Tamamlandı!";
 BUILDING_IPA = "IPA Oluşturuluyor... (Bu biraz zaman alabilir)";
 

--- a/Resources/uk.lproj/Localizable.strings
+++ b/Resources/uk.lproj/Localizable.strings
@@ -12,6 +12,7 @@ DECRYPT_APPS = "Розшифрувати додатки";
 DECRYPTED_FILES = "Розшифровані файли";
 
 DECRYPTED_IPAS = "Розшифровані IPA (%lu)";
+DECRYPTED_APP_BUNDLES = "Decrypted App Bundles (%lu)";
 DECRYPTED_BINARIES = "Розшифровані бінарні файли (%lu)";
 
 DECRYPTION_PROMPT = "Бажаєте розшифрувати %@?";
@@ -32,4 +33,5 @@ MANUAL_ENTRY_TITLE = "Введення ідентифікатора пакету
 MANUAL_ENTRY_SUBTITLE = "Введіть ідентифікатор пакету додатку, який бажаєте розшифрувати.";
 
 SHOW_IN_FILZA = "Показати у Filza";
+COPY_PATH = "Copy Path";
 SHOW_IN_FILES = "Показати у Файлах";

--- a/Resources/uk.lproj/Localizable.strings
+++ b/Resources/uk.lproj/Localizable.strings
@@ -22,6 +22,7 @@ FULL_IPA = "Повний IPA";
 LAUNCHING_APPLICATION = "Запуск додатку...";
 COPYING_BUNDLE = "Копіювання пакету додатку...";
 DECRYPTING_BINARY = "Розшифрування бінарного файлу...";
+SAVING_APP_BUNDLE = "Saving app bundle...";
 DECRYPTION_COMPLETED = "Розшифрування завершено!";
 BUILDING_IPA = "Створення IPA... (Це може зайняти хвилину)";
 

--- a/Resources/uk.lproj/Localizable.strings
+++ b/Resources/uk.lproj/Localizable.strings
@@ -16,6 +16,7 @@ DECRYPTED_BINARIES = "Розшифровані бінарні файли (%lu)";
 
 DECRYPTION_PROMPT = "Бажаєте розшифрувати %@?";
 MAIN_BINARY_ONLY = "Тільки головний бінарний файл";
+APP_BUNDLE_ONLY = "App Bundle Only";
 FULL_IPA = "Повний IPA";
 
 LAUNCHING_APPLICATION = "Запуск додатку...";

--- a/Resources/vi.lproj/Localizable.strings
+++ b/Resources/vi.lproj/Localizable.strings
@@ -16,6 +16,7 @@ DECRYPTED_BINARIES = "Tệp nhị phân đã giải mã (%lu)";
 
 DECRYPTION_PROMPT = "Bạn có muốn giải mã %@ không?";
 MAIN_BINARY_ONLY = "Chỉ tệp nhị phân chính";
+APP_BUNDLE_ONLY = "App Bundle Only";
 FULL_IPA = "Toàn bộ IPA";
 
 LAUNCHING_APPLICATION = "Đang khởi chạy ứng dụng...";

--- a/Resources/vi.lproj/Localizable.strings
+++ b/Resources/vi.lproj/Localizable.strings
@@ -22,6 +22,7 @@ FULL_IPA = "Toàn bộ IPA";
 LAUNCHING_APPLICATION = "Đang khởi chạy ứng dụng...";
 COPYING_BUNDLE = "Đang sao chép gói ứng dụng...";
 DECRYPTING_BINARY = "Đang giải mã tệp nhị phân...";
+SAVING_APP_BUNDLE = "Saving app bundle...";
 DECRYPTION_COMPLETED = "Giải mã thành công!";
 BUILDING_IPA = "Đang tạo IPA... (Quá trình này có thể mất một lúc)";
 

--- a/Resources/vi.lproj/Localizable.strings
+++ b/Resources/vi.lproj/Localizable.strings
@@ -12,6 +12,7 @@ DECRYPT_APPS = "Giải mã ứng dụng";
 DECRYPTED_FILES = "Tệp đã giải mã";
 
 DECRYPTED_IPAS = "IPA đã giải mã (%lu)";
+DECRYPTED_APP_BUNDLES = "Decrypted App Bundles (%lu)";
 DECRYPTED_BINARIES = "Tệp nhị phân đã giải mã (%lu)";
 
 DECRYPTION_PROMPT = "Bạn có muốn giải mã %@ không?";
@@ -32,4 +33,5 @@ MANUAL_ENTRY_TITLE = "Nhập mã định danh gói thủ công";
 MANUAL_ENTRY_SUBTITLE = "Nhập mã định danh gói của ứng dụng bạn muốn giải mã.";
 
 SHOW_IN_FILZA = "Hiển thị trong Filza";
+COPY_PATH = "Copy Path";
 SHOW_IN_FILES = "Hiển thị trong Tệp";

--- a/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Resources/zh-Hans.lproj/Localizable.strings
@@ -16,6 +16,7 @@ DECRYPTED_BINARIES = "已解密二进制文件（%lu）";
 
 DECRYPTION_PROMPT = "您要解密 %@ 吗？";
 MAIN_BINARY_ONLY = "仅主二进制文件";
+APP_BUNDLE_ONLY = "App Bundle Only";
 FULL_IPA = "完整 IPA";
 
 LAUNCHING_APPLICATION = "正在启动应用...";

--- a/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Resources/zh-Hans.lproj/Localizable.strings
@@ -12,6 +12,7 @@ DECRYPT_APPS = "解密应用";
 DECRYPTED_FILES = "已解密文件";
 
 DECRYPTED_IPAS = "已解密 IPA（%lu）";
+DECRYPTED_APP_BUNDLES = "Decrypted App Bundles (%lu)";
 DECRYPTED_BINARIES = "已解密二进制文件（%lu）";
 
 DECRYPTION_PROMPT = "您要解密 %@ 吗？";
@@ -32,4 +33,5 @@ MANUAL_ENTRY_TITLE = "手动输入 Bundle Identifier";
 MANUAL_ENTRY_SUBTITLE = "请输入您要解密的应用的 Bundle Identifier。";
 
 SHOW_IN_FILZA = "在 Filza 中显示";
+COPY_PATH = "Copy Path";
 SHOW_IN_FILES = "在文件中显示";

--- a/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Resources/zh-Hans.lproj/Localizable.strings
@@ -22,6 +22,7 @@ FULL_IPA = "完整 IPA";
 LAUNCHING_APPLICATION = "正在启动应用...";
 COPYING_BUNDLE = "正在复制应用包...";
 DECRYPTING_BINARY = "正在解密二进制文件...";
+SAVING_APP_BUNDLE = "Saving app bundle...";
 DECRYPTION_COMPLETED = "解密完成！";
 BUILDING_IPA = "正在构建 IPA...（可能需要一分钟）";
 

--- a/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Resources/zh-Hant.lproj/Localizable.strings
@@ -16,6 +16,7 @@ DECRYPTED_BINARIES = "已解密二進位檔（%lu）";
 
 DECRYPTION_PROMPT = "您要解密 %@ 嗎？";
 MAIN_BINARY_ONLY = "僅主二進位檔";
+APP_BUNDLE_ONLY = "App Bundle Only";
 FULL_IPA = "完整 IPA";
 
 LAUNCHING_APPLICATION = "正在啟動應用程式...";

--- a/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Resources/zh-Hant.lproj/Localizable.strings
@@ -22,6 +22,7 @@ FULL_IPA = "完整 IPA";
 LAUNCHING_APPLICATION = "正在啟動應用程式...";
 COPYING_BUNDLE = "正在複製應用程式套件...";
 DECRYPTING_BINARY = "正在解密二進位檔...";
+SAVING_APP_BUNDLE = "Saving app bundle...";
 DECRYPTION_COMPLETED = "解密完成！";
 BUILDING_IPA = "正在建立 IPA...（這可能需要一分鐘）";
 

--- a/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Resources/zh-Hant.lproj/Localizable.strings
@@ -12,6 +12,7 @@ DECRYPT_APPS = "解密應用程式";
 DECRYPTED_FILES = "已解密檔案";
 
 DECRYPTED_IPAS = "已解密 IPA（%lu）";
+DECRYPTED_APP_BUNDLES = "Decrypted App Bundles (%lu)";
 DECRYPTED_BINARIES = "已解密二進位檔（%lu）";
 
 DECRYPTION_PROMPT = "您要解密 %@ 嗎？";
@@ -32,4 +33,5 @@ MANUAL_ENTRY_TITLE = "手動輸入套件識別碼";
 MANUAL_ENTRY_SUBTITLE = "請輸入您想要解密的應用程式套件識別碼。";
 
 SHOW_IN_FILZA = "在 Filza 中顯示";
+COPY_PATH = "Copy Path";
 SHOW_IN_FILES = "在檔案中顯示";

--- a/TDApplicationListViewController.m
+++ b/TDApplicationListViewController.m
@@ -95,7 +95,14 @@ static inline NSUInteger getEffectiveIconFormat(void) {
             return;
         }
 
-        [self _decryptApplicationProxy:application];
+        [alert dismissViewControllerAnimated:YES completion:^{
+            UIView *sourceView = self.navigationController.navigationBar ?: self.view;
+            UIView *customView = self.navigationItem.rightBarButtonItem.customView;
+            CGRect sourceRect = customView
+                ? customView.frame
+                : CGRectMake(CGRectGetMaxX(sourceView.bounds) - 1.0, 0.0, 1.0, CGRectGetHeight(sourceView.bounds));
+            [self _presentDecryptionOptionsForApplication:application sourceView:sourceView sourceRect:sourceRect];
+        }];
     }];
     [alert addAction:cancelAction];
     [alert addAction:decryptAction];
@@ -190,38 +197,49 @@ static inline NSUInteger getEffectiveIconFormat(void) {
 }
 
 // TDDecryptionTask
-- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
-    LSApplicationProxy *application = _filteredApplications[indexPath.row];
-
+- (void)_presentDecryptionOptionsForApplication:(LSApplicationProxy *)application
+                                     sourceView:(UIView *)sourceView
+                                     sourceRect:(CGRect)sourceRect {
     NSString *title = [Localize localizedStringForKey:@"DECRYPT"];
     NSString *subtitle = [NSString stringWithFormat:[Localize localizedStringForKey:@"DECRYPTION_PROMPT"], [application atl_nameToDisplay]];
-    // UIAlertController *alert = [UIAlertController alertControllerWithTitle:[Localize localizedStringForKey:@"DECRYPT"] message:[NSString stringWithFormat:@"Do you want to decrypt %@?", [application atl_nameToDisplay]] preferredStyle:UIAlertControllerStyleActionSheet];
     UIAlertController *alert = [UIAlertController alertControllerWithTitle:title message:subtitle preferredStyle:UIAlertControllerStyleActionSheet];
+    void (^decryptWithOptions)(TDDecryptionTaskOptions) = ^(TDDecryptionTaskOptions options) {
+        [self _decryptApplicationProxy:application options:options];
+    };
 
+    UIAlertAction *fullIPAAction = [UIAlertAction actionWithTitle:[Localize localizedStringForKey:@"FULL_IPA"] style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+        decryptWithOptions(TDDecryptionTaskDefaultOptions());
+    }];
+    [alert addAction:fullIPAAction];
+
+    UIAlertAction *appBundleOnlyAction = [UIAlertAction actionWithTitle:[Localize localizedStringForKey:@"APP_BUNDLE_ONLY"] style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+        decryptWithOptions(TDDecryptionTaskOptionsMake(TDDecryptionOutputModeAppBundleOnly));
+    }];
+    [alert addAction:appBundleOnlyAction];
+
+    UIAlertAction *mainBinaryOnlyAction = [UIAlertAction actionWithTitle:[Localize localizedStringForKey:@"MAIN_BINARY_ONLY"] style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+        decryptWithOptions(TDDecryptionTaskOptionsMake(TDDecryptionOutputModeMainBinaryOnly));
+    }];
+    [alert addAction:mainBinaryOnlyAction];
 
     UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:[Localize localizedStringForKey:@"CANCEL"] style:UIAlertActionStyleCancel handler:nil];
     [alert addAction:cancelAction];
 
-    UIAlertAction *decryptBinaryOnlyAction = [UIAlertAction actionWithTitle:[Localize localizedStringForKey:@"MAIN_BINARY_ONLY"] style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-        TDDecryptionTaskOptions options = TDDecryptionTaskOptionsMake(true);
-        [self _decryptApplicationProxy:application options:options];
-    }];
-    [alert addAction:decryptBinaryOnlyAction];
-
-    UIAlertAction *decryptAction = [UIAlertAction actionWithTitle:[Localize localizedStringForKey:@"FULL_IPA"] style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-        [self _decryptApplicationProxy:application];
-    }];
-    [alert addAction:decryptAction];
-
     // iPad popover fix - @NightwindDev
     UIPopoverPresentationController *popover = alert.popoverPresentationController;
     if (popover) {
-        popover.sourceView = self.view;
-        popover.sourceRect = [tableView rectForRowAtIndexPath:indexPath];
+        popover.sourceView = sourceView ?: self.view;
+        popover.sourceRect = sourceRect;
         popover.permittedArrowDirections = UIPopoverArrowDirectionAny;
     }
 
     [self presentViewController:alert animated:YES completion:nil];
+}
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    LSApplicationProxy *application = _filteredApplications[indexPath.row];
+
+    [self _presentDecryptionOptionsForApplication:application sourceView:self.view sourceRect:[tableView rectForRowAtIndexPath:indexPath]];
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
 }
 

--- a/TDApplicationListViewController.m
+++ b/TDApplicationListViewController.m
@@ -285,6 +285,13 @@ static inline NSUInteger getEffectiveIconFormat(void) {
                         [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
                     }]];
                 }
+
+                BOOL appBundleOnly = (options.outputMode == TDDecryptionOutputModeAppBundleOnly);
+                if (appBundleOnly) {
+                    [resultAlert addAction:[UIAlertAction actionWithTitle:[Localize localizedStringForKey:@"COPY_PATH"] style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+                        [UIPasteboard generalPasteboard].string = outputURL.path;
+                    }]];
+                }
             } else {
                 resultAlert = [UIAlertController alertControllerWithTitle:[Localize localizedStringForKey:@"ERROR"] message:error.localizedDescription preferredStyle:UIAlertControllerStyleAlert];
             }

--- a/TDFileManagerViewController.m
+++ b/TDFileManagerViewController.m
@@ -163,6 +163,31 @@
     return totalSize;
 }
 
+- (void)_presentLocationActionsForURL:(NSURL *)url sourceView:(UIView *)sourceView sourceRect:(CGRect)sourceRect {
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:url.lastPathComponent message:url.path preferredStyle:UIAlertControllerStyleActionSheet];
+
+    if ([[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:@"filza://"]]) {
+        [alert addAction:[UIAlertAction actionWithTitle:[Localize localizedStringForKey:@"SHOW_IN_FILZA"] style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+            NSURL *filzaURL = [[NSURL URLWithString:@"filza://view"] URLByAppendingPathComponent:url.path];
+            [[UIApplication sharedApplication] openURL:filzaURL options:@{} completionHandler:nil];
+        }]];
+    }
+
+    [alert addAction:[UIAlertAction actionWithTitle:[Localize localizedStringForKey:@"COPY_PATH"] style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+        [UIPasteboard generalPasteboard].string = url.path;
+    }]];
+    [alert addAction:[UIAlertAction actionWithTitle:[Localize localizedStringForKey:@"CANCEL"] style:UIAlertActionStyleCancel handler:nil]];
+
+    UIPopoverPresentationController *popover = alert.popoverPresentationController;
+    if (popover) {
+        popover.sourceView = sourceView ?: self.view;
+        popover.sourceRect = sourceRect;
+        popover.permittedArrowDirections = UIPopoverArrowDirectionAny;
+    }
+
+    [self presentViewController:alert animated:YES completion:nil];
+}
+
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"DecryptedFileCell"];
     if (!cell) cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:@"DecryptedFileCell"];
@@ -211,13 +236,7 @@
 
 - (UISwipeActionsConfiguration *)tableView:(UITableView *)tableView trailingSwipeActionsConfigurationForRowAtIndexPath:(NSIndexPath *)indexPath {
     UIContextualAction *deleteAction = [UIContextualAction contextualActionWithStyle:UIContextualActionStyleDestructive title:[Localize localizedStringForKey:@"Delete"] handler:^(UIContextualAction *action, __kindof UIView *sourceView, void (^completionHandler)(BOOL)) {
-        // NSURL *fileURL = _decryptedIPAURLs[indexPath.row];
-        NSURL *fileURL;
-        if (indexPath.section == 0) {
-            fileURL = _decryptedIPAURLs[indexPath.row];
-        } else {
-            fileURL = _decryptedBinaries[indexPath.row];
-        }
+        NSURL *fileURL = [self _outputURLForIndexPath:indexPath];
         [[NSFileManager defaultManager] removeItemAtURL:fileURL error:nil];
 
         [self reload];
@@ -230,11 +249,13 @@
 }
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
-    NSURL *fileURL;
-    if (indexPath.section == 0) {
-        fileURL = _decryptedIPAURLs[indexPath.row];
-    } else {
-        fileURL = _decryptedBinaries[indexPath.row];
+    NSURL *fileURL = [self _outputURLForIndexPath:indexPath];
+
+    if ([self _indexPathIsAppBundle:indexPath]) {
+        UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
+        [self _presentLocationActionsForURL:fileURL sourceView:cell.contentView sourceRect:cell.contentView.bounds];
+        [tableView deselectRowAtIndexPath:indexPath animated:YES];
+        return;
     }
 
     UIActivityViewController *activityViewController = [[UIActivityViewController alloc] initWithActivityItems:@[ fileURL ] applicationActivities:nil];

--- a/TDFileManagerViewController.m
+++ b/TDFileManagerViewController.m
@@ -235,9 +235,20 @@
 }
 
 - (UISwipeActionsConfiguration *)tableView:(UITableView *)tableView trailingSwipeActionsConfigurationForRowAtIndexPath:(NSIndexPath *)indexPath {
-    UIContextualAction *deleteAction = [UIContextualAction contextualActionWithStyle:UIContextualActionStyleDestructive title:[Localize localizedStringForKey:@"Delete"] handler:^(UIContextualAction *action, __kindof UIView *sourceView, void (^completionHandler)(BOOL)) {
+    UIContextualAction *deleteAction = [UIContextualAction contextualActionWithStyle:UIContextualActionStyleDestructive title:[Localize localizedStringForKey:@"DELETE"] handler:^(UIContextualAction *action, __kindof UIView *sourceView, void (^completionHandler)(BOOL)) {
         NSURL *fileURL = [self _outputURLForIndexPath:indexPath];
-        [[NSFileManager defaultManager] removeItemAtURL:fileURL error:nil];
+        NSError *removeError = nil;
+        BOOL removed = [[NSFileManager defaultManager] removeItemAtURL:fileURL error:&removeError];
+        if (!removed) {
+            completionHandler(NO);
+
+            UIAlertController *alert = [UIAlertController alertControllerWithTitle:[Localize localizedStringForKey:@"ERROR"]
+                                                                           message:removeError.localizedDescription
+                                                                    preferredStyle:UIAlertControllerStyleAlert];
+            [alert addAction:[UIAlertAction actionWithTitle:[Localize localizedStringForKey:@"OK"] style:UIAlertActionStyleDefault handler:nil]];
+            [self presentViewController:alert animated:YES completion:nil];
+            return;
+        }
 
         [self reload];
 

--- a/TDFileManagerViewController.m
+++ b/TDFileManagerViewController.m
@@ -7,13 +7,14 @@
 @implementation TDFileManagerViewController {
     UIView *_noFilesInfoView;
     NSMutableArray<NSURL *> *_decryptedIPAURLs;
+    NSMutableArray<NSURL *> *_decryptedAppBundleURLs;
     NSMutableArray<NSURL *> *_decryptedBinaries;
 }
 
 - (instancetype)init {
     self = [super init];
     if (self) {
-        [self loadDecryptedIPAs];
+        [self loadDecryptedOutputs];
     }
     return self;
 }
@@ -32,8 +33,9 @@
     [self reload];
 }
 
-- (void)loadDecryptedIPAs {
+- (void)loadDecryptedOutputs {
     NSMutableArray<NSURL *> *decryptedIPAURLs = [NSMutableArray new];
+    NSMutableArray<NSURL *> *decryptedAppBundleURLs = [NSMutableArray new];
     NSMutableArray<NSURL *> *decryptedBinaries = [NSMutableArray new];
 
     NSArray *files = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:ROOT_OUTPUT_PATH error:nil];
@@ -41,7 +43,14 @@
     for (NSString *filename in files) {
         NSURL *fileURL = [[NSURL fileURLWithPath:ROOT_OUTPUT_PATH] URLByAppendingPathComponent:filename];
         BOOL isDirectory = NO;
-        if (![[NSFileManager defaultManager] fileExistsAtPath:fileURL.path isDirectory:&isDirectory] || isDirectory) {
+        if (![[NSFileManager defaultManager] fileExistsAtPath:fileURL.path isDirectory:&isDirectory]) {
+            continue;
+        }
+
+        if (isDirectory) {
+            if ([fileURL.pathExtension.lowercaseString isEqualToString:@"app"]) {
+                [decryptedAppBundleURLs addObject:fileURL];
+            }
             continue;
         }
 
@@ -73,18 +82,19 @@
     }
 
     _decryptedIPAURLs = [decryptedIPAURLs copy];
+    _decryptedAppBundleURLs = [decryptedAppBundleURLs copy];
     _decryptedBinaries = [decryptedBinaries copy];
 }
 
 - (void)reload {
-    [self loadDecryptedIPAs];
+    [self loadDecryptedOutputs];
     [self.tableView reloadData];
     [self.refreshControl endRefreshing];
     [self updateEmptyState];
 }
 
 - (void)updateEmptyState {
-    if (_decryptedIPAURLs.count == 0 && _decryptedBinaries.count == 0) {
+    if (_decryptedIPAURLs.count == 0 && _decryptedAppBundleURLs.count == 0 && _decryptedBinaries.count == 0) {
         self.tableView.backgroundView = [self noFilesInfoView];
     } else {
         self.tableView.backgroundView = nil;
@@ -92,12 +102,14 @@
 }
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
-    return 2;
+    return 3;
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
     if (section == 0) {
         return _decryptedIPAURLs.count;
+    } else if (section == 1) {
+        return _decryptedAppBundleURLs.count;
     } else {
         return _decryptedBinaries.count;
     }
@@ -109,6 +121,9 @@
     if (section == 0) {
         format = [Localize localizedStringForKey:@"DECRYPTED_IPAS"];
         count = _decryptedIPAURLs.count;
+    } else if (section == 1) {
+        format = [Localize localizedStringForKey:@"DECRYPTED_APP_BUNDLES"];
+        count = _decryptedAppBundleURLs.count;
     } else {
         format = [Localize localizedStringForKey:@"DECRYPTED_BINARIES"];
         count = _decryptedBinaries.count;
@@ -117,23 +132,55 @@
     return [NSString stringWithFormat:format, (unsigned long)count];
 }
 
+- (NSURL *)_outputURLForIndexPath:(NSIndexPath *)indexPath {
+    if (indexPath.section == 0) return _decryptedIPAURLs[indexPath.row];
+    if (indexPath.section == 1) return _decryptedAppBundleURLs[indexPath.row];
+    return _decryptedBinaries[indexPath.row];
+}
+
+- (BOOL)_indexPathIsAppBundle:(NSIndexPath *)indexPath {
+    return indexPath.section == 1;
+}
+
+- (unsigned long long)_recursiveSizeOfDirectoryAtURL:(NSURL *)url {
+    unsigned long long totalSize = 0;
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSDirectoryEnumerator *enumerator =
+        [fileManager enumeratorAtURL:url
+          includingPropertiesForKeys:@[ NSURLFileSizeKey ]
+                             options:0
+                        errorHandler:^BOOL(NSURL *unreadableURL, NSError *error) {
+                            NSLog(@"Skipping unreadable output item %@: %@", unreadableURL.path, error);
+                            return YES;
+                        }];
+
+    for (NSURL *itemURL in enumerator) {
+        NSNumber *fileSize = nil;
+        if ([itemURL getResourceValue:&fileSize forKey:NSURLFileSizeKey error:nil]) {
+            totalSize += fileSize.unsignedLongLongValue;
+        }
+    }
+    return totalSize;
+}
+
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"DecryptedFileCell"];
     if (!cell) cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:@"DecryptedFileCell"];
 
-    NSURL *fileURL;
+    NSURL *fileURL = [self _outputURLForIndexPath:indexPath];
     NSString *imageName;
     if (indexPath.section == 0) {
-        fileURL = _decryptedIPAURLs[indexPath.row];
         imageName = @"doc.zipper";
+    } else if (indexPath.section == 1) {
+        imageName = @"folder.fill";
     } else {
-        fileURL = _decryptedBinaries[indexPath.row];
         imageName = @"doc.fill";
     }
 
     NSDictionary *attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:fileURL.path error:nil];
     NSDate *modificationDate = attributes[NSFileModificationDate];
     NSNumber *fileSize = attributes[NSFileSize];
+    unsigned long long outputSize = [self _indexPathIsAppBundle:indexPath] ? [self _recursiveSizeOfDirectoryAtURL:fileURL] : fileSize.unsignedLongLongValue;
     
     NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
     [dateFormatter setDateFormat:@"MMM d, yyyy h:mm a"];
@@ -144,7 +191,7 @@
     cell.imageView.image = [UIImage systemImageNamed:imageName];
 
     UILabel *fileSizeLabel = [[UILabel alloc] init];
-    fileSizeLabel.text = [NSString stringWithFormat:@"%.2f MB", [fileSize doubleValue] / (1024.0 * 1024.0)];
+    fileSizeLabel.text = [NSString stringWithFormat:@"%.2f MB", (double)outputSize / (1024.0 * 1024.0)];
     fileSizeLabel.textColor = [UIColor systemGray2Color];
     fileSizeLabel.font = [UIFont systemFontOfSize:12.0f];
     [fileSizeLabel sizeToFit];


### PR DESCRIPTION
## Summary

This adds an **App Bundle Only** output mode for TrollDecrypt.

The main motivation is storage pressure on older devices. When decrypting a larger app or game on something like an older iPad, generating a full `.ipa` means the device needs room for both the copied decrypted `.app` bundle and the final archive. For large games, that can be enough to make the workflow fail even though the actual decrypted app bundle would fit.

With this mode, TrollDecrypt can now save the fully decrypted `.app` bundle directly under the normal TrollDecrypt output folder without also packaging it into an `.ipa`.

## Why

My use case is decrypting games on an iPad Air 2 with only 16GB of storage (most of which is used by the system), then moving the decrypted bundle to an Apple silicon Mac to package, install, and play from there. The iPad is the device that can decrypt the app, but it is not always the best place to also build the final archive. I know it's possible to only decrypt the main binary, but that adds more steps in the process like hunting for the UUID. 

This keeps the existing full IPA workflow intact, while making the low-storage path possible.

## Changes

- Added a third decrypt option: **App Bundle Only**
- Saves decrypted `.app` bundles under the existing TrollDecrypt output directory
- Avoids creating the extra IPA archive in app-bundle-only mode
- Shows saved app bundles in the output browser
- Adds actions for locating or sharing app bundle outputs
- Cleans up partial app bundle outputs if the task fails

## Notes

Full IPA and Main Binary Only behavior should remain unchanged. The new path is only used when App Bundle Only is selected.
